### PR TITLE
Hotfix for NPE on removing a PDR

### DIFF
--- a/app/api/src/main/java/org/omecproject/up4/ForwardingActionRule.java
+++ b/app/api/src/main/java/org/omecproject/up4/ForwardingActionRule.java
@@ -44,6 +44,18 @@ public final class ForwardingActionRule {
         this.type = type;
     }
 
+    /**
+     * Return a new instance of this FAR with the action parameters stripped, leaving only the match keys.
+     *
+     * @return a new FAR with only match keys
+     */
+    public ForwardingActionRule withoutActionParams() {
+        return ForwardingActionRule.builder()
+                .withFarId(farId)
+                .withSessionId(sessionId)
+                .build();
+    }
+
     public static Builder builder() {
         return new Builder();
     }

--- a/app/api/src/main/java/org/omecproject/up4/PacketDetectionRule.java
+++ b/app/api/src/main/java/org/omecproject/up4/PacketDetectionRule.java
@@ -107,6 +107,23 @@ public final class PacketDetectionRule {
     }
 
     /**
+     * Return a new instance of this PDR with the action parameters stripped, leaving only the match keys.
+     *
+     * @return a new PDR with only match keys
+     */
+    public PacketDetectionRule withoutActionParams() {
+        if (isUplink()) {
+            return PacketDetectionRule.builder()
+                    .withTeid(teid)
+                    .withTunnelDst(tunnelDst)
+                    .build();
+        } else {
+            return PacketDetectionRule.builder()
+                    .withUeAddr(ueAddr).build();
+        }
+    }
+
+    /**
      * True if this PDR matches on packets travelling in the uplink direction, and false otherwise.
      *
      * @return true if the PDR matches only uplink packets

--- a/app/app/src/test/java/org/omecproject/up4/behavior/FabricUpfProgrammableTest.java
+++ b/app/app/src/test/java/org/omecproject/up4/behavior/FabricUpfProgrammableTest.java
@@ -48,7 +48,7 @@ public class FabricUpfProgrammableTest {
         for (var readPdr : installedPdrs) {
             assertThat(readPdr, equalTo(expectedPdr));
         }
-        upfProgrammable.removePdr(expectedPdr);
+        upfProgrammable.removePdr(expectedPdr.withoutActionParams());
         assertTrue(upfProgrammable.getInstalledPdrs().isEmpty());
     }
 
@@ -62,7 +62,7 @@ public class FabricUpfProgrammableTest {
         for (var readPdr : installedPdrs) {
             assertThat(readPdr, equalTo(expectedPdr));
         }
-        upfProgrammable.removePdr(expectedPdr);
+        upfProgrammable.removePdr(expectedPdr.withoutActionParams());
         assertTrue(upfProgrammable.getInstalledPdrs().isEmpty());
     }
 
@@ -76,7 +76,7 @@ public class FabricUpfProgrammableTest {
         for (var readFar : installedFars) {
             assertThat(readFar, equalTo(expectedFar));
         }
-        upfProgrammable.removeFar(expectedFar);
+        upfProgrammable.removeFar(expectedFar.withoutActionParams());
         assertTrue(upfProgrammable.getInstalledFars().isEmpty());
     }
 
@@ -90,7 +90,7 @@ public class FabricUpfProgrammableTest {
         for (var readFar : installedFars) {
             assertThat(readFar, equalTo(expectedFar));
         }
-        upfProgrammable.removeFar(expectedFar);
+        upfProgrammable.removeFar(expectedFar.withoutActionParams());
         assertTrue(upfProgrammable.getInstalledFars().isEmpty());
     }
 


### PR DESCRIPTION
This hotfix prevents a NPE on PDR removals, and modifies the unit tests for entry removal to ensure such an issue will be caught later. Unfortunately, this hotfix also adds a linear-time set to PDR removal which should be optimized out ASAP.