### PR TITLE
Add requested changes to rule string representations

### DIFF
--- a/app/api/src/main/java/org/omecproject/up4/ForwardingActionRule.java
+++ b/app/api/src/main/java/org/omecproject/up4/ForwardingActionRule.java
@@ -9,7 +9,6 @@ import org.onlab.util.ImmutableByteSequence;
 
 import java.util.Objects;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -25,23 +24,21 @@ public final class ForwardingActionRule {
     private final ImmutableByteSequence sessionId;  // The PFCP session identifier that created this FAR
     private final int farId;  // PFCP session-local identifier for this FAR
     // Action parameters
-    private final Boolean drop;  // Should this FAR drop packets?
-    private final Boolean notifyCp;  // Should this FAR notify the control plane when it sees a packet?
-    private final boolean buffer;   // Should this FAR buffer incoming packets?
+    private final boolean notifyFlag;  // Should this FAR notify the control plane when it sees a packet?
+    private final boolean dropFlag;
+    private final boolean bufferFlag;
     private final GtpTunnel tunnel;  // The GTP tunnel that this FAR should encapsulate packets with (if downlink)
-    private final Type type;  // Is the FAR Uplink, Downlink, etc
 
     private static final int SESSION_ID_BITWIDTH = 96;
 
     private ForwardingActionRule(ImmutableByteSequence sessionId, Integer farId,
-                                 Boolean drop, Boolean notifyCp, boolean buffer, GtpTunnel tunnel, Type type) {
+                                 boolean notifyFlag, GtpTunnel tunnel, boolean dropFlag, boolean bufferFlag) {
         this.sessionId = sessionId;
         this.farId = farId;
-        this.drop = drop;
-        this.buffer = buffer;
-        this.notifyCp = notifyCp;
+        this.notifyFlag = notifyFlag;
         this.tunnel = tunnel;
-        this.type = type;
+        this.dropFlag = dropFlag;
+        this.bufferFlag = bufferFlag;
     }
 
     /**
@@ -51,7 +48,7 @@ public final class ForwardingActionRule {
      */
     public ForwardingActionRule withoutActionParams() {
         return ForwardingActionRule.builder()
-                .withFarId(farId)
+                .setFarId(farId)
                 .withSessionId(sessionId)
                 .build();
     }
@@ -66,23 +63,21 @@ public final class ForwardingActionRule {
      * @return a string representing the FAR action
      */
     public String actionString() {
-        String actionName = "NO_ACTION";
+        String actionName;
         String actionParams = "";
-        if (hasActionParameters()) {
-            if (drop) {
-                actionName = "Drop";
-            } else if (buffer) {
-                actionName = "Buffer";
-            } else if (tunnel != null) {
-                actionName = "Encap";
-                actionParams = String.format("Src=%s, SPort=%d, TEID=%s, Dst=%s",
-                        tunnel.src().toString(), tunnel.srcPort(), tunnel.teid().toString(), tunnel.dst().toString());
-            } else {
-                actionName = "Forward";
-            }
-            if (notifyCp) {
-                actionName += "+NotifyCP";
-            }
+        if (dropFlag) {
+            actionName = "Drop";
+        } else if (bufferFlag) {
+            actionName = "Buffer";
+        } else if (tunnel != null) {
+            actionName = "Encap";
+            actionParams = String.format("Src=%s, SPort=%d, TEID=%s, Dst=%s",
+                    tunnel.src().toString(), tunnel.srcPort(), tunnel.teid().toString(), tunnel.dst().toString());
+        } else {
+            actionName = "Forward";
+        }
+        if (notifyFlag) {
+            actionName += "+NotifyCP";
         }
 
         return String.format("%s(%s)", actionName, actionParams);
@@ -110,45 +105,17 @@ public final class ForwardingActionRule {
         ForwardingActionRule that = (ForwardingActionRule) obj;
 
         // Safe comparisons between potentially null objects
-        return (this.type.equals(that.type) &&
-                (this.farId == that.farId) &&
+        return (this.dropFlag == that.dropFlag &&
+                this.bufferFlag == that.bufferFlag &&
+                this.notifyFlag == that.notifyFlag &&
+                this.farId == that.farId &&
                 Objects.equals(this.tunnel, that.tunnel) &&
-                Objects.equals(this.drop, that.drop) &&
-                Objects.equals(this.notifyCp, that.notifyCp) &&
                 Objects.equals(this.sessionId, that.sessionId));
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(sessionId, farId, drop, notifyCp, tunnel, type);
-    }
-
-    /**
-     * Instances created as a result of DELETE write requests will not have action parameters, only match keys.
-     * This method should be used to avoid null pointer exceptions in those instances.
-     *
-     * @return true if this instance has FAR action parameters, false otherwise.
-     */
-    public boolean hasActionParameters() {
-        return type != Type.KEYS_ONLY;
-    }
-
-    /**
-     * True if this FAR forwards packets without encapsulating, and false otherwise.
-     *
-     * @return true if FAR is forwards without encapsulating
-     */
-    public boolean isUplink() {
-        return type == Type.UPLINK;
-    }
-
-    /**
-     * True if this FAR tunnels packets before forwarding, and false otherwise.
-     *
-     * @return true is FAR encapsulates
-     */
-    public boolean isDownlink() {
-        return type == Type.DOWNLINK;
+        return Objects.hash(sessionId, farId, notifyFlag, tunnel, dropFlag, bufferFlag);
     }
 
     /**
@@ -170,12 +137,30 @@ public final class ForwardingActionRule {
     }
 
     /**
+     * True if this FAR does not drop packets.
+     *
+     * @return true if FAR is forwards
+     */
+    public boolean forwards() {
+        return !dropFlag;
+    }
+
+    /**
+     * True if this FAR encapsulates packets in a GTP tunnel, and false otherwise.
+     *
+     * @return true is FAR encapsulates
+     */
+    public boolean encaps() {
+        return tunnel != null;
+    }
+
+    /**
      * Returns true if this FAR drops packets, and false otherwise.
      *
      * @return true if this FAR drops
      */
-    public boolean dropFlag() {
-        return drop;
+    public boolean drops() {
+        return dropFlag;
     }
 
     /**
@@ -183,8 +168,8 @@ public final class ForwardingActionRule {
      *
      * @return true if this FAR notifies the cp
      */
-    public boolean notifyCpFlag() {
-        return notifyCp;
+    public boolean notifies() {
+        return notifyFlag;
     }
 
 
@@ -193,8 +178,8 @@ public final class ForwardingActionRule {
      *
      * @return true if this FAR buffers
      */
-    public boolean bufferFlag() {
-        return buffer;
+    public boolean buffers() {
+        return bufferFlag;
     }
 
     /**
@@ -252,36 +237,15 @@ public final class ForwardingActionRule {
         return tunnel.teid();
     }
 
-    public enum Type {
-        /**
-         * Uplink FARs apply to packets traveling in the uplink direction, and do not encapsulate.
-         */
-        UPLINK,
-        /**
-         * Downlink FARS apply to packets traveling in the downlink direction, and do encapsulate.
-         */
-        DOWNLINK,
-        /**
-         * FAR was not built with any action parameters, only match keys.
-         */
-        KEYS_ONLY
-    }
-
     public static class Builder {
-        private ImmutableByteSequence sessionId;
-        private Integer farId;
-        private Boolean drop;
-        private Boolean notifyCp;
-        private boolean buffer;
-        private GtpTunnel tunnel;
+        private ImmutableByteSequence sessionId = null;
+        private Integer farId = null;
+        private GtpTunnel tunnel = null;
+        private boolean dropFlag = false;
+        private boolean bufferFlag = false;
+        private boolean notifyCp = false;
 
         public Builder() {
-            sessionId = null;
-            farId = null;
-            drop = null;
-            notifyCp = null;
-            tunnel = null;
-            buffer = false;
         }
 
         /**
@@ -316,34 +280,41 @@ public final class ForwardingActionRule {
          * @param farId PFCP session-local FAR ID
          * @return This builder object
          */
-        public Builder withFarId(int farId) {
+        public Builder setFarId(int farId) {
             this.farId = farId;
             return this;
         }
 
-
         /**
-         * Set flags specifying whether this FAR should drop packets and/or notify the control plane when
-         * any packets arrive.
+         * Make this FAR forward incoming packets.
          *
-         * @param drop     true if this FAR drops
-         * @param notifyCp true if this FAR notifies the control plane
+         * @param flag the flag value to set
          * @return This builder object
          */
-        public Builder withFlags(boolean drop, boolean notifyCp) {
-            this.drop = drop;
-            this.notifyCp = notifyCp;
+        public Builder setForwardFlag(boolean flag) {
+            this.dropFlag = !flag;
             return this;
         }
 
         /**
-         * Set a flag specifying if this FAR drops traffic or not.
+         * Make this FAR drop incoming packets.
          *
-         * @param drop true if FAR drops
+         * @param flag the flag value to set
          * @return This builder object
          */
-        public Builder withDropFlag(boolean drop) {
-            this.drop = drop;
+        public Builder setDropFlag(boolean flag) {
+            this.dropFlag = flag;
+            return this;
+        }
+
+        /**
+         * Make this FAR buffer incoming packets.
+         *
+         * @param flag the flag value to set
+         * @return This builder object
+         */
+        public Builder setBufferFlag(boolean flag) {
+            this.bufferFlag = flag;
             return this;
         }
 
@@ -353,19 +324,8 @@ public final class ForwardingActionRule {
          * @param notifyCp true if FAR notifies control plane
          * @return This builder object
          */
-        public Builder withNotifyFlag(boolean notifyCp) {
+        public Builder setNotifyFlag(boolean notifyCp) {
             this.notifyCp = notifyCp;
-            return this;
-        }
-
-        /**
-         * Set a flag specifying if this FAR should buffer incoming packets.
-         *
-         * @param buffer true if this FAR buffers packets
-         * @return This builder object
-         */
-        public Builder withBufferFlag(boolean buffer) {
-            this.buffer = buffer;
             return this;
         }
 
@@ -375,7 +335,7 @@ public final class ForwardingActionRule {
          * @param tunnel GTP tunnel
          * @return This builder object
          */
-        public Builder withTunnel(GtpTunnel tunnel) {
+        public Builder setTunnel(GtpTunnel tunnel) {
             this.tunnel = tunnel;
             return this;
         }
@@ -388,8 +348,8 @@ public final class ForwardingActionRule {
          * @param teid GTP tunnel ID
          * @return This builder object
          */
-        public Builder withTunnel(Ip4Address src, Ip4Address dst, ImmutableByteSequence teid) {
-            return this.withTunnel(GtpTunnel.builder()
+        public Builder setTunnel(Ip4Address src, Ip4Address dst, ImmutableByteSequence teid) {
+            return this.setTunnel(GtpTunnel.builder()
                     .setSrc(src)
                     .setDst(dst)
                     .setTeid(teid)
@@ -405,8 +365,8 @@ public final class ForwardingActionRule {
          * @param srcPort GTP tunnel UDP source port (destination port is hardcoded as 2152)
          * @return This builder object
          */
-        public Builder withTunnel(Ip4Address src, Ip4Address dst, ImmutableByteSequence teid, short srcPort) {
-            return this.withTunnel(GtpTunnel.builder()
+        public Builder setTunnel(Ip4Address src, Ip4Address dst, ImmutableByteSequence teid, short srcPort) {
+            return this.setTunnel(GtpTunnel.builder()
                     .setSrc(src)
                     .setDst(dst)
                     .setTeid(teid)
@@ -418,19 +378,7 @@ public final class ForwardingActionRule {
             // All match keys are required
             checkNotNull(sessionId, "Session ID is required");
             checkNotNull(farId, "FAR ID is required");
-            // Action parameters are optional. If the tunnel desc is provided, the flags must also be provided.
-            checkArgument((drop != null && notifyCp != null) ||
-                            (drop == null && notifyCp == null && tunnel == null),
-                    "FAR Arguments must be provided together or not at all.");
-            Type type;
-            if (drop == null && notifyCp == null) {
-                type = Type.KEYS_ONLY;
-            } else if (tunnel == null) {
-                type = Type.UPLINK;
-            } else {
-                type = Type.DOWNLINK;
-            }
-            return new ForwardingActionRule(sessionId, farId, drop, notifyCp, buffer, tunnel, type);
+            return new ForwardingActionRule(sessionId, farId, notifyCp, tunnel, dropFlag, bufferFlag);
         }
     }
 }

--- a/app/api/src/main/java/org/omecproject/up4/PacketDetectionRule.java
+++ b/app/api/src/main/java/org/omecproject/up4/PacketDetectionRule.java
@@ -22,13 +22,13 @@ import static com.google.common.base.Preconditions.checkArgument;
 public final class PacketDetectionRule {
     // Match keys
     private final Ip4Address ueAddr;  // The UE IP address that this PDR matches on
-    private final ImmutableByteSequence teid;  // The Tunnel Endpoint ID that this PDR matches on (if PDR is uplink)
-    private final Ip4Address tunnelDst;  // The tunnel destination address that this PDR matches on (if PDR is uplink)
+    private final ImmutableByteSequence teid;  // The Tunnel Endpoint ID that this PDR matches on
+    private final Ip4Address tunnelDst;  // The tunnel destination address that this PDR matches on
     // Action parameters
     private final ImmutableByteSequence sessionId;  // The ID of the PFCP session that created this PDR
     private final Integer ctrId;  // Counter ID unique to this PDR
     private final Integer farId;  // The PFCP session-local ID of the FAR that should apply after this PDR hits
-    private final Type type; // Is the PDR Uplink, Downlink, etc.
+    private final Type type;
 
     private static final int SESSION_ID_BITWIDTH = 96;
 
@@ -53,7 +53,7 @@ public final class PacketDetectionRule {
      * @return a string representing the PDR match conditions
      */
     public String matchString() {
-        if (isUplink()) {
+        if (matchesEncapped()) {
             return String.format("Match(Dst=%s, TEID=%s)", tunnelDest(), teid());
         } else {
             return String.format("Match(Dst=%s, !GTP)", ueAddress());
@@ -106,7 +106,7 @@ public final class PacketDetectionRule {
      * @return true if this instance has PDR action parameters, false otherwise.
      */
     public boolean hasActionParameters() {
-        return type == Type.UPLINK || type == Type.DOWNLINK;
+        return type == Type.MATCH_ENCAPPED || type == Type.MATCH_UNENCAPPED;
     }
 
     /**
@@ -115,7 +115,7 @@ public final class PacketDetectionRule {
      * @return a new PDR with only match keys
      */
     public PacketDetectionRule withoutActionParams() {
-        if (isUplink()) {
+        if (matchesEncapped()) {
             return PacketDetectionRule.builder()
                     .withTeid(teid)
                     .withTunnelDst(tunnelDst)
@@ -127,21 +127,21 @@ public final class PacketDetectionRule {
     }
 
     /**
-     * True if this PDR matches on packets travelling in the uplink direction, and false otherwise.
+     * True if this PDR matches on packets received with a GTP header, and false otherwise.
      *
-     * @return true if the PDR matches only uplink packets
+     * @return true if the PDR matches only encapsulated packets
      */
-    public boolean isUplink() {
-        return type == Type.UPLINK || type == Type.UPLINK_KEYS_ONLY;
+    public boolean matchesEncapped() {
+        return type == Type.MATCH_ENCAPPED || type == Type.MATCH_ENCAPPED_NO_ACTION;
     }
 
     /**
-     * True if this PDR matches on packets travelling in the downlink direction, and false otherwise.
+     * True if this PDR matches on packets received without a GTP header, and false otherwise.
      *
-     * @return true if the PDR matches only downlink packets
+     * @return true if the PDR matches only unencapsulated packets
      */
-    public boolean isDownlink() {
-        return type == Type.DOWNLINK || type == Type.DOWNLINK_KEYS_ONLY;
+    public boolean matchesUnencapped() {
+        return type == Type.MATCH_UNENCAPPED || type == Type.MATCH_UNENCAPPED_NO_ACTION;
     }
 
     /**
@@ -200,24 +200,23 @@ public final class PacketDetectionRule {
 
     public enum Type {
         /**
-         * Uplink PDRs match on packets travelling in the uplink direction. These packets will have a GTP tunnel.
+         * Match on packets that are encapsulated in a GTP tunnel.
          */
-        UPLINK,
+        MATCH_ENCAPPED,
         /**
-         * Downlink PDRs match on packets travelling in the downlink direction.
-         * These packets will not have a GTP tunnel.
+         * Match on packets that are not encapsulated in a GTP tunnel.
          */
-        DOWNLINK,
+        MATCH_UNENCAPPED,
         /**
-         * For uplink PDRs that were not build with any action parameters, only match keys.
+         * For PDRs that match on encapsulated packets but do not yet have any action parameters set.
          * These are usually built in the context of P4Runtime DELETE write requests.
          */
-        UPLINK_KEYS_ONLY,
+        MATCH_ENCAPPED_NO_ACTION,
         /**
-         * For downlink PDRs that were not build with any action parameters, only match keys.
+         * For PDRs that match on unencapsulated packets but do not yet have any action parameters set.
          * These are usually built in the context of P4Runtime DELETE write requests.
          */
-        DOWNLINK_KEYS_ONLY
+        MATCH_UNENCAPPED_NO_ACTION
     }
 
     public static class Builder {
@@ -349,15 +348,15 @@ public final class PacketDetectionRule {
             Type type;
             if (teid != null) {
                 if (sessionId != null) {
-                    type = Type.UPLINK;
+                    type = Type.MATCH_ENCAPPED;
                 } else {
-                    type = Type.UPLINK_KEYS_ONLY;
+                    type = Type.MATCH_ENCAPPED_NO_ACTION;
                 }
             } else {
                 if (sessionId != null) {
-                    type = Type.DOWNLINK;
+                    type = Type.MATCH_UNENCAPPED;
                 } else {
-                    type = Type.DOWNLINK_KEYS_ONLY;
+                    type = Type.MATCH_UNENCAPPED_NO_ACTION;
                 }
             }
             return new PacketDetectionRule(sessionId, ctrId, localFarId, ueAddr, teid, tunnelDst, type);

--- a/app/api/src/main/java/org/omecproject/up4/UpfFlow.java
+++ b/app/api/src/main/java/org/omecproject/up4/UpfFlow.java
@@ -161,12 +161,12 @@ public final class UpfFlow {
                             "Counter statistics provided do not use counter index set by provided PDR!");
                 }
                 sessionId = pdr.sessionId();
-                type = pdr.isUplink() ? Type.UPLINK : Type.DOWNLINK;
+                type = pdr.matchesEncapped() ? Type.UPLINK : Type.DOWNLINK;
             } else if (far != null) {
                 sessionId = far.sessionId();
-                if (far.isUplink()) {
+                if (far.forwards()) {
                     type = Type.UPLINK;
-                } else if (far.isDownlink()) {
+                } else if (far.encaps()) {
                     type = Type.DOWNLINK;
                 }
             }

--- a/app/api/src/main/java/org/omecproject/up4/UpfInterface.java
+++ b/app/api/src/main/java/org/omecproject/up4/UpfInterface.java
@@ -31,9 +31,9 @@ public final class UpfInterface {
     public String toString() {
         String typeStr;
         if (type.equals(Type.ACCESS)) {
-            typeStr = "Uplink";
+            typeStr = "Access";
         } else if (type.equals(Type.CORE)) {
-            typeStr = "Downlink";
+            typeStr = "Core";
         } else if (type.equals(Type.DBUF)) {
             typeStr = "Dbuf-Receiver";
         } else {
@@ -64,33 +64,33 @@ public final class UpfInterface {
     }
 
     /**
-     * Create an uplink UPF Interface from the given address, which will be treated as a /32 prefix.
+     * Create a core-facing UPF Interface from the given address, which will be treated as a /32 prefix.
      *
-     * @param address the address of the new uplink interface
+     * @param address the address of the new core-facing interface
      * @return a new UPF interface
      */
     public static UpfInterface createS1uFrom(Ip4Address address) {
-        return builder().setUplink().setPrefix(Ip4Prefix.valueOf(address, 32)).build();
+        return builder().setAccess().setPrefix(Ip4Prefix.valueOf(address, 32)).build();
     }
 
     /**
-     * Create an uplink UPF Interface from the given IP prefix.
+     * Create an access-facing UPF Interface from the given IP prefix.
      *
-     * @param prefix the prefix of the new uplink interface
+     * @param prefix the prefix of the new access-facing interface
      * @return a new UPF interface
      */
     public static UpfInterface createS1uFrom(Ip4Prefix prefix) {
-        return builder().setUplink().setPrefix(prefix).build();
+        return builder().setAccess().setPrefix(prefix).build();
     }
 
     /**
-     * Create an downlink UPF Interface from the given IP prefix.
+     * Create a core-facing UPF Interface from the given IP prefix.
      *
-     * @param prefix the prefix of the new downlink interface
+     * @param prefix the prefix of the new core-facing interface
      * @return a new UPF interface
      */
     public static UpfInterface createUePoolFrom(Ip4Prefix prefix) {
-        return builder().setDownlink().setPrefix(prefix).build();
+        return builder().setCore().setPrefix(prefix).build();
     }
 
     /**
@@ -113,22 +113,22 @@ public final class UpfInterface {
     }
 
     /**
-     * Check if this UPF interface is for uplink packets from UEs.
+     * Check if this UPF interface is for packets traveling from UEs.
      * This will be true for S1U interface table entries.
      *
-     * @return true if uplink
+     * @return true if interface receives from access
      */
-    public boolean isUplink() {
+    public boolean isAccess() {
         return type == Type.ACCESS;
     }
 
     /**
-     * Check if this UPF interface is for downlink packets towards UEs.
+     * Check if this UPF interface is for packets traveling towards UEs.
      * This will be true for UE IP address pool table entries.
      *
-     * @return true if downlink
+     * @return true if interface receives from core
      */
-    public boolean isDownlink() {
+    public boolean isCore() {
         return type == Type.CORE;
     }
 
@@ -159,13 +159,13 @@ public final class UpfInterface {
         UNKNOWN,
 
         /**
-         * Uplink interface that receives GTP encapsulated packets.
+         * Interface that receives GTP encapsulated packets.
          * This is the type of the S1U interface.
          */
         ACCESS,
 
         /**
-         * Downlink interface that receives unencapsulated packets from the core of the network.
+         * Interface that receives unencapsulated packets from the core of the network.
          * This is the type of UE IP address pool interfaces.
          */
         CORE,
@@ -207,21 +207,21 @@ public final class UpfInterface {
         }
 
         /**
-         * Make this an uplink interface.
+         * Make this an access-facing interface.
          *
          * @return this builder object
          */
-        public Builder setUplink() {
+        public Builder setAccess() {
             this.type = Type.ACCESS;
             return this;
         }
 
         /**
-         * Make this a downlink interface.
+         * Make this a core-facing interface.
          *
          * @return this builder object
          */
-        public Builder setDownlink() {
+        public Builder setCore() {
             this.type = Type.CORE;
             return this;
         }

--- a/app/app/src/main/java/org/omecproject/up4/behavior/Up4TranslatorImpl.java
+++ b/app/app/src/main/java/org/omecproject/up4/behavior/Up4TranslatorImpl.java
@@ -151,13 +151,13 @@ public class Up4TranslatorImpl implements Up4Translator {
                 .withSessionId(farId.getPfcpSessionId());
 
         if (TranslatorUtil.fieldIsPresent(match, SouthConstants.HDR_TEID)) {
-            // F-TEID is only present for uplink PDRs
+            // F-TEID is only present for GTP-matching PDRs
             ImmutableByteSequence teid = TranslatorUtil.getFieldValue(match, SouthConstants.HDR_TEID);
             Ip4Address tunnelDst = TranslatorUtil.getFieldAddress(match, SouthConstants.HDR_TUNNEL_IPV4_DST);
             pdrBuilder.withTeid(teid)
                     .withTunnelDst(tunnelDst);
         } else if (TranslatorUtil.fieldIsPresent(match, SouthConstants.HDR_UE_ADDR)) {
-            // And UE address is only present for downlink PDRs
+            // And UE address is only present for non-GTP-matching PDRs
             pdrBuilder.withUeAddr(TranslatorUtil.getFieldAddress(match, SouthConstants.HDR_UE_ADDR));
         } else {
             throw new Up4TranslationException("Read malformed PDR from dataplane!:" + entry);
@@ -173,11 +173,11 @@ public class Up4TranslatorImpl implements Up4Translator {
 
         int srcInterface = TranslatorUtil.getFieldInt(entry, NorthConstants.SRC_IFACE_KEY);
         if (srcInterface == NorthConstants.IFACE_ACCESS) {
-            // Uplink entries will match on the F-TEID (tunnel destination address + TEID)
+            // GTP-matching PDRs will match on the F-TEID (tunnel destination address + TEID)
             pdrBuilder.withTunnel(TranslatorUtil.getFieldValue(entry, NorthConstants.TEID_KEY),
                     TranslatorUtil.getFieldAddress(entry, NorthConstants.TUNNEL_DST_KEY));
         } else if (srcInterface == NorthConstants.IFACE_CORE) {
-            // Downlink entries will match on the UE address
+            // Non-GTP-matching PDRs will match on the UE address
             pdrBuilder.withUeAddr(TranslatorUtil.getFieldAddress(entry, NorthConstants.UE_ADDR_KEY));
         } else {
             throw new Up4TranslationException("Flexible PDRs not yet supported.");
@@ -213,32 +213,31 @@ public class Up4TranslatorImpl implements Up4Translator {
 
         // Match keys
         farBuilder.withSessionId(farId.getPfcpSessionId())
-                .withFarId(farId.getSessionLocalId());
+                .setFarId(farId.getSessionLocalId());
 
-        // Parameters common to uplink and downlink should always be present
-        farBuilder.withDropFlag(dropFlag)
-                .withNotifyFlag(notifyFlag);
+        // Parameters common to all types of FARs
+        farBuilder.setDropFlag(dropFlag)
+                .setNotifyFlag(notifyFlag);
 
         PiActionId actionId = action.id();
 
         if (actionId.equals(SouthConstants.FABRIC_INGRESS_SPGW_LOAD_TUNNEL_FAR)
                 || actionId.equals(SouthConstants.FABRIC_INGRESS_SPGW_LOAD_DBUF_FAR)) {
-            // Grab parameters specific to downlink FARs if they're present
+            // Grab parameters specific to encapsulating FARs if they're present
             Ip4Address tunnelSrc = TranslatorUtil.getParamAddress(action, SouthConstants.TUNNEL_SRC_ADDR);
             Ip4Address tunnelDst = TranslatorUtil.getParamAddress(action, SouthConstants.TUNNEL_DST_ADDR);
             ImmutableByteSequence teid = TranslatorUtil.getParamValue(action, SouthConstants.TEID);
             short tunnelSrcPort = (short) TranslatorUtil.getParamInt(action, SouthConstants.TUNNEL_SRC_PORT);
 
-            boolean farBuffers = actionId.equals(SouthConstants.FABRIC_INGRESS_SPGW_LOAD_DBUF_FAR);
+            farBuilder.setBufferFlag(actionId.equals(SouthConstants.FABRIC_INGRESS_SPGW_LOAD_DBUF_FAR));
 
-            farBuilder.withTunnel(
+            farBuilder.setTunnel(
                     GtpTunnel.builder()
                             .setSrc(tunnelSrc)
                             .setDst(tunnelDst)
                             .setTeid(teid)
                             .setSrcPort(tunnelSrcPort)
-                            .build())
-                    .withBufferFlag(farBuffers);
+                            .build());
         }
         return farBuilder.build();
     }
@@ -250,24 +249,24 @@ public class Up4TranslatorImpl implements Up4Translator {
         ImmutableByteSequence sessionId = TranslatorUtil.getFieldValue(entry, NorthConstants.SESSION_ID_KEY);
         int localFarId = TranslatorUtil.getFieldInt(entry, NorthConstants.FAR_ID_KEY);
         var farBuilder = ForwardingActionRule.builder()
-                .withFarId(localFarId)
+                .setFarId(localFarId)
                 .withSessionId(sessionId);
 
         // Now get the action parameters, if they are present (entries from delete writes don't have parameters)
         PiAction action = (PiAction) entry.action();
         PiActionId actionId = action.id();
         if (!action.parameters().isEmpty()) {
-            // Parameters that both types of FAR have
-            farBuilder.withDropFlag(TranslatorUtil.getParamInt(entry, NorthConstants.DROP_FLAG) > 0)
-                    .withNotifyFlag(TranslatorUtil.getParamInt(entry, NorthConstants.NOTIFY_FLAG) > 0);
+            // Parameters that all types of fars have
+            farBuilder.setDropFlag(TranslatorUtil.getParamInt(entry, NorthConstants.DROP_FLAG) > 0)
+                    .setNotifyFlag(TranslatorUtil.getParamInt(entry, NorthConstants.NOTIFY_FLAG) > 0);
             if (actionId.equals(NorthConstants.LOAD_FAR_TUNNEL)) {
-                // Parameters exclusive to a downlink FAR
-                farBuilder.withTunnel(
+                // Parameters exclusive to encapsulating FARs
+                farBuilder.setTunnel(
                         TranslatorUtil.getParamAddress(entry, NorthConstants.TUNNEL_SRC_PARAM),
                         TranslatorUtil.getParamAddress(entry, NorthConstants.TUNNEL_DST_PARAM),
                         TranslatorUtil.getParamValue(entry, NorthConstants.TEID_PARAM),
                         (short) TranslatorUtil.getParamInt(entry, NorthConstants.TUNNEL_SPORT_PARAM))
-                        .withBufferFlag(TranslatorUtil.getParamInt(entry, NorthConstants.BUFFER_FLAG) > 0);
+                        .setBufferFlag(TranslatorUtil.getParamInt(entry, NorthConstants.BUFFER_FLAG) > 0);
             }
         }
         return farBuilder.build();
@@ -278,9 +277,9 @@ public class Up4TranslatorImpl implements Up4Translator {
         var builder = UpfInterface.builder();
         int srcIfaceTypeInt = TranslatorUtil.getParamInt(entry, NorthConstants.SRC_IFACE_PARAM);
         if (srcIfaceTypeInt == NorthConstants.IFACE_ACCESS) {
-            builder.setUplink();
+            builder.setAccess();
         } else if (srcIfaceTypeInt == NorthConstants.IFACE_CORE) {
-            builder.setDownlink();
+            builder.setCore();
         } else {
             throw new Up4TranslationException("Attempting to translate an unsupported UP4 interface type! " +
                     srcIfaceTypeInt);
@@ -302,9 +301,9 @@ public class Up4TranslatorImpl implements Up4Translator {
 
         int interfaceType = TranslatorUtil.getParamInt(action, SouthConstants.SRC_IFACE);
         if (interfaceType == SouthConstants.INTERFACE_ACCESS) {
-            ifaceBuilder.setUplink();
+            ifaceBuilder.setAccess();
         } else if (interfaceType == SouthConstants.INTERFACE_CORE) {
-            ifaceBuilder.setDownlink();
+            ifaceBuilder.setCore();
         } else if (interfaceType == SouthConstants.INTERFACE_DBUF) {
             ifaceBuilder.setDbufReceiver();
         }
@@ -316,38 +315,36 @@ public class Up4TranslatorImpl implements Up4Translator {
     public FlowRule farToFabricEntry(ForwardingActionRule far, DeviceId deviceId, ApplicationId appId, int priority)
             throws Up4TranslationException {
         PiAction action;
-        if (far.isUplink()) {
+        if (!far.encaps()) {
             action = PiAction.builder()
                     .withId(SouthConstants.FABRIC_INGRESS_SPGW_LOAD_NORMAL_FAR)
                     .withParameters(Arrays.asList(
-                            new PiActionParam(SouthConstants.DROP, far.dropFlag() ? 1 : 0),
-                            new PiActionParam(SouthConstants.NOTIFY_CP, far.notifyCpFlag() ? 1 : 0)
+                            new PiActionParam(SouthConstants.DROP, far.drops() ? 1 : 0),
+                            new PiActionParam(SouthConstants.NOTIFY_CP, far.notifies() ? 1 : 0)
                     ))
                     .build();
 
-        } else if (far.isDownlink() || far.bufferFlag()) {
+        } else {
             if (far.tunnelSrc() == null || far.tunnelDst() == null
                     || far.teid() == null || far.tunnel().srcPort() == null) {
                 throw new Up4TranslationException(
                         "Not all action parameters present when translating " +
-                                "intermediate downlink FAR to physical FAR!");
+                                "intermediate encapsulating/buffering FAR to physical FAR!");
             }
             // TODO: copy tunnel destination port from logical switch write requests, instead of hardcoding 2152
-            PiActionId actionId = far.bufferFlag() ? SouthConstants.FABRIC_INGRESS_SPGW_LOAD_DBUF_FAR :
+            PiActionId actionId = far.buffers() ? SouthConstants.FABRIC_INGRESS_SPGW_LOAD_DBUF_FAR :
                     SouthConstants.FABRIC_INGRESS_SPGW_LOAD_TUNNEL_FAR;
             action = PiAction.builder()
                     .withId(actionId)
                     .withParameters(Arrays.asList(
-                            new PiActionParam(SouthConstants.DROP, far.dropFlag() ? 1 : 0),
-                            new PiActionParam(SouthConstants.NOTIFY_CP, far.notifyCpFlag() ? 1 : 0),
+                            new PiActionParam(SouthConstants.DROP, far.drops() ? 1 : 0),
+                            new PiActionParam(SouthConstants.NOTIFY_CP, far.notifies() ? 1 : 0),
                             new PiActionParam(SouthConstants.TEID, far.teid()),
                             new PiActionParam(SouthConstants.TUNNEL_SRC_ADDR, far.tunnelSrc().toInt()),
                             new PiActionParam(SouthConstants.TUNNEL_DST_ADDR, far.tunnelDst().toInt()),
                             new PiActionParam(SouthConstants.TUNNEL_SRC_PORT, far.tunnel().srcPort())
                     ))
                     .build();
-        } else {
-            throw new Up4TranslationException("Attempting to translate a FAR of unknown direction to fabric entry!");
         }
         PiCriterion match = PiCriterion.builder()
                 .matchExact(SouthConstants.HDR_FAR_ID, globalFarIdOf(far.sessionId(), far.farId()))
@@ -366,13 +363,13 @@ public class Up4TranslatorImpl implements Up4Translator {
             throws Up4TranslationException {
         PiCriterion match;
         PiTableId tableId;
-        if (pdr.isUplink()) {
+        if (pdr.matchesEncapped()) {
             match = PiCriterion.builder()
                     .matchExact(SouthConstants.HDR_TEID, pdr.teid().asArray())
                     .matchExact(SouthConstants.HDR_TUNNEL_IPV4_DST, pdr.tunnelDest().toInt())
                     .build();
             tableId = SouthConstants.FABRIC_INGRESS_SPGW_UPLINK_PDRS;
-        } else if (pdr.isDownlink()) {
+        } else if (pdr.matchesUnencapped()) {
             match = PiCriterion.builder()
                     .matchExact(SouthConstants.HDR_UE_ADDR, pdr.ueAddress().toInt())
                     .build();
@@ -386,7 +383,7 @@ public class Up4TranslatorImpl implements Up4Translator {
                 .withParameters(Arrays.asList(
                         new PiActionParam(SouthConstants.CTR_ID, pdr.counterId()),
                         new PiActionParam(SouthConstants.FAR_ID, globalFarIdOf(pdr.sessionId(), pdr.farId())),
-                        new PiActionParam(SouthConstants.NEEDS_GTPU_DECAP, pdr.isUplink() ? 1 : 0)
+                        new PiActionParam(SouthConstants.NEEDS_GTPU_DECAP, pdr.matchesEncapped() ? 1 : 0)
                 ))
                 .build();
 
@@ -407,7 +404,7 @@ public class Up4TranslatorImpl implements Up4Translator {
         if (upfInterface.isDbufReceiver()) {
             interfaceTypeInt = SouthConstants.INTERFACE_DBUF;
             gtpuValidity = 1;
-        } else if (upfInterface.isUplink()) {
+        } else if (upfInterface.isAccess()) {
             interfaceTypeInt = SouthConstants.INTERFACE_ACCESS;
             gtpuValidity = 1;
         } else {
@@ -440,26 +437,26 @@ public class Up4TranslatorImpl implements Up4Translator {
         PiAction action;
         ImmutableByteSequence zeroByte = ImmutableByteSequence.ofZeros(1);
         ImmutableByteSequence oneByte = ImmutableByteSequence.ofOnes(1);
-        if (far.isUplink()) {
+        if (!far.encaps()) {
             action = PiAction.builder()
                     .withId(NorthConstants.LOAD_FAR_NORMAL)
                     .withParameters(Arrays.asList(
-                            new PiActionParam(NorthConstants.DROP_FLAG, far.dropFlag() ? oneByte : zeroByte),
-                            new PiActionParam(NorthConstants.NOTIFY_FLAG, far.notifyCpFlag() ? oneByte : zeroByte)
+                            new PiActionParam(NorthConstants.DROP_FLAG, far.drops() ? oneByte : zeroByte),
+                            new PiActionParam(NorthConstants.NOTIFY_FLAG, far.notifies() ? oneByte : zeroByte)
                     ))
                     .build();
-        } else if (far.isDownlink()) {
+        } else {
             if (far.tunnelSrc() == null || far.tunnelDst() == null
                     || far.teid() == null || far.tunnel().srcPort() == null) {
                 throw new Up4TranslationException(
-                        "Not all action parameters present when translating intermediate downlink FAR to logical FAR!");
+                        "Not all action parameters present when translating intermediate encap FAR to logical FAR!");
             }
             action = PiAction.builder()
                     .withId(NorthConstants.LOAD_FAR_TUNNEL)
                     .withParameters(Arrays.asList(
-                            new PiActionParam(NorthConstants.DROP_FLAG, far.dropFlag() ? oneByte : zeroByte),
-                            new PiActionParam(NorthConstants.NOTIFY_FLAG, far.notifyCpFlag() ? oneByte : zeroByte),
-                            new PiActionParam(NorthConstants.BUFFER_FLAG, far.bufferFlag() ? oneByte : zeroByte),
+                            new PiActionParam(NorthConstants.DROP_FLAG, far.drops() ? oneByte : zeroByte),
+                            new PiActionParam(NorthConstants.NOTIFY_FLAG, far.notifies() ? oneByte : zeroByte),
+                            new PiActionParam(NorthConstants.BUFFER_FLAG, far.buffers() ? oneByte : zeroByte),
                             new PiActionParam(NorthConstants.TUNNEL_TYPE_PARAM,
                                     toImmutableByte(NorthConstants.TUNNEL_TYPE_GTPU)),
                             new PiActionParam(NorthConstants.TUNNEL_SRC_PARAM, far.tunnelSrc().toInt()),
@@ -468,9 +465,6 @@ public class Up4TranslatorImpl implements Up4Translator {
                             new PiActionParam(NorthConstants.TUNNEL_SPORT_PARAM, far.tunnel().srcPort())
                     ))
                     .build();
-        } else {
-            throw new Up4TranslationException(
-                    "FARs that are not uplink or downlink cannot yet be translated northward!");
         }
         matchKey = PiMatchKey.builder()
                 .addFieldMatch(new PiExactFieldMatch(NorthConstants.FAR_ID_KEY,
@@ -490,8 +484,8 @@ public class Up4TranslatorImpl implements Up4Translator {
         PiMatchKey matchKey;
         PiAction action;
         int decapFlag;
-        if (pdr.isUplink()) {
-            decapFlag = 1;  // Decap is true for uplink
+        if (pdr.matchesEncapped()) {
+            decapFlag = 1;
             matchKey = PiMatchKey.builder()
                     .addFieldMatch(new PiExactFieldMatch(NorthConstants.SRC_IFACE_KEY,
                             toImmutableByte(NorthConstants.IFACE_ACCESS)))
@@ -499,17 +493,14 @@ public class Up4TranslatorImpl implements Up4Translator {
                     .addFieldMatch(new PiTernaryFieldMatch(NorthConstants.TUNNEL_DST_KEY,
                             ImmutableByteSequence.copyFrom(pdr.tunnelDest().toOctets()), allOnes32))
                     .build();
-        } else if (pdr.isDownlink()) {
-            decapFlag = 0;  // Decap is false for downlink
+        } else {
+            decapFlag = 0;
             matchKey = PiMatchKey.builder()
                     .addFieldMatch(new PiExactFieldMatch(NorthConstants.SRC_IFACE_KEY,
                             toImmutableByte(NorthConstants.IFACE_CORE)))
                     .addFieldMatch(new PiTernaryFieldMatch(NorthConstants.UE_ADDR_KEY,
                             ImmutableByteSequence.copyFrom(pdr.ueAddress().toOctets()), allOnes32))
                     .build();
-        } else {
-            throw new Up4TranslationException(
-                    "PDRs that are not uplink or downlink cannot yet be translated northward!");
         }
         // FIXME: pdr_id is not yet stored on writes so it cannot be read
         action = PiAction.builder()
@@ -541,8 +532,8 @@ public class Up4TranslatorImpl implements Up4Translator {
 
     @Override
     public PiTableEntry interfaceToUp4Entry(UpfInterface upfInterface) throws Up4TranslationException {
-        int srcIface = upfInterface.isUplink() ? NorthConstants.IFACE_ACCESS : NorthConstants.IFACE_CORE;
-        int direction = upfInterface.isUplink() ? NorthConstants.DIRECTION_UPLINK : NorthConstants.DIRECTION_DOWNLINK;
+        int srcIface = upfInterface.isAccess() ? NorthConstants.IFACE_ACCESS : NorthConstants.IFACE_CORE;
+        int direction = upfInterface.isAccess() ? NorthConstants.DIRECTION_UPLINK : NorthConstants.DIRECTION_DOWNLINK;
         return PiTableEntry.builder()
                 .forTable(NorthConstants.IFACE_TBL)
                 .withMatchKey(PiMatchKey.builder()

--- a/app/app/src/main/java/org/omecproject/up4/cli/FarDeleteCommand.java
+++ b/app/app/src/main/java/org/omecproject/up4/cli/FarDeleteCommand.java
@@ -35,7 +35,7 @@ public class FarDeleteCommand extends AbstractShellCommand {
 
         ForwardingActionRule far = ForwardingActionRule.builder()
                 .withSessionId(sessionId)
-                .withFarId(farId)
+                .setFarId(farId)
                 .build();
         print("Deleting %s", far.toString());
         app.getUpfProgrammable().removeFar(far);

--- a/app/app/src/main/java/org/omecproject/up4/cli/FarInsertCommand.java
+++ b/app/app/src/main/java/org/omecproject/up4/cli/FarInsertCommand.java
@@ -51,12 +51,11 @@ public class FarInsertCommand extends AbstractShellCommand {
         Up4Service app = get(Up4Service.class);
 
         var farBuilder = ForwardingActionRule.builder()
-                .withFarId(farId)
-                .withSessionId(sessionId)
-                .withFlags(false, false);
+                .setFarId(farId)
+                .withSessionId(sessionId);
 
         if (teid != -1) {
-            farBuilder.withTunnel(GtpTunnel.builder()
+            farBuilder.setTunnel(GtpTunnel.builder()
                     .setSrc(Ip4Address.valueOf(tunnelSrc))
                     .setDst(Ip4Address.valueOf(tunnelDst))
                     .setTeid(teid)

--- a/app/app/src/test/java/org/omecproject/up4/behavior/TestConstants.java
+++ b/app/app/src/test/java/org/omecproject/up4/behavior/TestConstants.java
@@ -71,16 +71,13 @@ public final class TestConstants {
             .build();
 
     public static final ForwardingActionRule UPLINK_FAR = ForwardingActionRule.builder()
-            .withFarId(UPLINK_FAR_ID)
-            .withFlags(false, false)
+            .setFarId(UPLINK_FAR_ID)
             .withSessionId(SESSION_ID).build();
 
     public static final ForwardingActionRule DOWNLINK_FAR = ForwardingActionRule.builder()
-            .withFarId(DOWNLINK_FAR_ID)
-            .withFlags(false, false)
-            .withBufferFlag(false)
+            .setFarId(DOWNLINK_FAR_ID)
             .withSessionId(SESSION_ID)
-            .withTunnel(S1U_ADDR, ENB_ADDR, TEID, TUNNEL_SPORT)
+            .setTunnel(S1U_ADDR, ENB_ADDR, TEID, TUNNEL_SPORT)
             .build();
 
     public static final UpfInterface UPLINK_INTERFACE = UpfInterface.createS1uFrom(S1U_IFACE);

--- a/app/app/src/test/java/org/omecproject/up4/behavior/Up4TranslatorImplTest.java
+++ b/app/app/src/test/java/org/omecproject/up4/behavior/Up4TranslatorImplTest.java
@@ -46,7 +46,7 @@ public class Up4TranslatorImplTest {
             assertThat("UP4 uplink PDR should translate to abstract PDR without error.", false);
             return;
         }
-        assertThat("Translated PDR should be uplink.", translatedPdr.isUplink());
+        assertThat("Translated PDR should be uplink.", translatedPdr.matchesEncapped());
         assertThat(translatedPdr, equalTo(expectedPdr));
     }
 
@@ -60,7 +60,7 @@ public class Up4TranslatorImplTest {
             assertThat("Fabric uplink PDR should translate to abstract PDR without error.", false);
             return;
         }
-        assertThat("Translated PDR should be uplink.", translatedPdr.isUplink());
+        assertThat("Translated PDR should be uplink.", translatedPdr.matchesEncapped());
         assertThat(translatedPdr, equalTo(expectedPdr));
     }
 
@@ -75,7 +75,7 @@ public class Up4TranslatorImplTest {
             return;
         }
 
-        assertThat("Translated PDR should be downlink.", translatedPdr.isDownlink());
+        assertThat("Translated PDR should be downlink.", translatedPdr.matchesUnencapped());
         assertThat(translatedPdr, equalTo(expectedPdr));
     }
 
@@ -90,7 +90,7 @@ public class Up4TranslatorImplTest {
             return;
         }
 
-        assertThat("Translated PDR should be downlink.", translatedPdr.isDownlink());
+        assertThat("Translated PDR should be downlink.", translatedPdr.matchesUnencapped());
         assertThat(translatedPdr, equalTo(expectedPdr));
     }
 
@@ -105,7 +105,7 @@ public class Up4TranslatorImplTest {
                     false);
             return;
         }
-        assertThat("Translated FAR should be uplink.", translatedFar.isUplink());
+        assertThat("Translated FAR should be uplink.", translatedFar.forwards());
         assertThat(translatedFar, equalTo(expectedFar));
     }
 
@@ -120,7 +120,7 @@ public class Up4TranslatorImplTest {
                     false);
             return;
         }
-        assertThat("Translated FAR should be uplink.", translatedFar.isUplink());
+        assertThat("Translated FAR should be uplink.", translatedFar.forwards());
         assertThat(translatedFar, equalTo(expectedFar));
     }
 
@@ -135,7 +135,7 @@ public class Up4TranslatorImplTest {
                     false);
             return;
         }
-        assertThat("Translated FAR should be downlink.", translatedFar.isDownlink());
+        assertThat("Translated FAR should be downlink.", translatedFar.encaps());
         assertThat(translatedFar, equalTo(expectedFar));
     }
 
@@ -150,7 +150,7 @@ public class Up4TranslatorImplTest {
                     false);
             return;
         }
-        assertThat("Translated FAR should be downlink.", translatedFar.isDownlink());
+        assertThat("Translated FAR should be downlink.", translatedFar.encaps());
         assertThat(translatedFar, equalTo(expectedFar));
     }
 
@@ -165,7 +165,7 @@ public class Up4TranslatorImplTest {
                     false);
             return;
         }
-        assertThat("Translated interface should be uplink.", translatedInterface.isUplink());
+        assertThat("Translated interface should be uplink.", translatedInterface.isAccess());
         assertThat(translatedInterface, equalTo(expectedInterface));
     }
 
@@ -180,7 +180,7 @@ public class Up4TranslatorImplTest {
                     false);
             return;
         }
-        assertThat("Translated interface should be uplink.", translatedInterface.isUplink());
+        assertThat("Translated interface should be uplink.", translatedInterface.isAccess());
         assertThat(translatedInterface, equalTo(expectedInterface));
     }
 
@@ -195,7 +195,7 @@ public class Up4TranslatorImplTest {
                     false);
             return;
         }
-        assertThat("Translated interface should be downlink.", translatedInterface.isDownlink());
+        assertThat("Translated interface should be downlink.", translatedInterface.isCore());
         assertThat(translatedInterface, equalTo(expectedInterface));
     }
 
@@ -210,7 +210,7 @@ public class Up4TranslatorImplTest {
                     false);
             return;
         }
-        assertThat("Translated interface should be downlink.", translatedInterface.isDownlink());
+        assertThat("Translated interface should be downlink.", translatedInterface.isCore());
         assertThat(translatedInterface, equalTo(expectedInterface));
     }
 


### PR DESCRIPTION
Here is a preview of how the new format looks. CLI outputs and logging outputs use the same string representation

```
onos@root > up4:read-fars                                                         03:13:06
FAR{Match(ID=2, SEID=0x1) -> Encap(Src=140.0.100.254, SPort=2152, TEID=0xff, Dst=140.0.100.1)}
FAR{Match(ID=1, SEID=0x1) -> Forward()}
onos@root > up4:read-pdrs                                                         03:14:45
PDR{Match(Dst=17.0.0.1, !GTP) -> LoadParams(SEID=0x1, FAR=2, CtrIdx=2)}
PDR{Match(Dst=140.0.100.254, TEID=0xff) -> LoadParams(SEID=0x1, FAR=1, CtrIdx=1)}
onos@root > up4:read-flows                                                        03:14:49
SEID:0x1 - Match(Dst=140.0.100.254, TEID=0xff)  -->  FarID 1  -->  Forward();
    >>     0 Ingress pkts ->     0 Egress pkts
SEID:0x1 - Match(Dst=17.0.0.1, !GTP)  -->  FarID 2  -->  Encap(Src=140.0.100.254, SPort=2152, TEID=0xff, Dst=140.0.100.1);
    >>     0 Ingress pkts ->     0 Egress pkts
2 flows found
onos@root >
```