### PR TITLE
Reject invalid UP4 FAR entry

### DIFF
--- a/app/app/src/test/java/org/omecproject/up4/behavior/TestConstants.java
+++ b/app/app/src/test/java/org/omecproject/up4/behavior/TestConstants.java
@@ -169,6 +169,21 @@ public final class TestConstants {
                     .build())
             .build();
 
+    public static final PiTableEntry INVALID_UP4_DOWNLINK_FAR = PiTableEntry.builder()
+            .forTable(NorthConstants.FAR_TBL)
+            .withMatchKey(PiMatchKey.builder()
+                    .addFieldMatch(new PiExactFieldMatch(NorthConstants.FAR_ID_KEY,
+                            ImmutableByteSequence.copyFrom(DOWNLINK_FAR_ID)))
+                    .addFieldMatch(new PiExactFieldMatch(NorthConstants.SESSION_ID_KEY, SESSION_ID))
+                    .build())
+            .withAction(PiAction.builder()
+                    .withId(NorthConstants.LOAD_FAR_NORMAL)
+                    .withParameters(Arrays.asList(
+                            new PiActionParam(NorthConstants.DROP_FLAG, FALSE_BYTE),
+                            new PiActionParam(NorthConstants.NOTIFY_FLAG, TRUE_BYTE)))
+                    .build())
+            .build();
+
     public static final PiTableEntry UP4_UPLINK_INTERFACE = PiTableEntry.builder()
             .forTable(NorthConstants.IFACE_TBL)
             .withMatchKey(PiMatchKey.builder()

--- a/app/app/src/test/java/org/omecproject/up4/behavior/Up4TranslatorImplTest.java
+++ b/app/app/src/test/java/org/omecproject/up4/behavior/Up4TranslatorImplTest.java
@@ -191,5 +191,14 @@ public class Up4TranslatorImplTest {
         assertThat(translatedRule, equalTo(expectedRule));
     }
 
-
+    @Test
+    public void invalidUp4EntryToDownlinkFarTest() {
+        try {
+            up4Translator.up4EntryToFar(TestConstants.INVALID_UP4_DOWNLINK_FAR);
+        } catch (Up4Translator.Up4TranslationException e) {
+            assertThat(e.getMessage(), equalTo("Forward + NotifyCP action is not allowed."));
+            return;
+        }
+        assertThat("The translator should throw an exception", false);
+    }
 }


### PR DESCRIPTION
This PR adds a check in the UP4 translator to reject/return an error when receiving a FAR entry with "Forward+NotifyCP" action.

Fix #133