### PR TITLE
Fix maven build

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -16,6 +16,7 @@ pipeline {
   environment {
     UP4_ENV = "${up4Env}"
     CODECOV_TOKEN = "26252f52-8c2d-4cfd-bd2f-ec00a71d2942"
+    JAVA_HOME = "/usr/lib/jvm/java-11-amazon-corretto"
   }
 
   stages {
@@ -49,7 +50,6 @@ pipeline {
         }
         // Set JDK 11
         sh "sudo update-java-alternatives -s java-11-amazon-corretto"
-        sh "export JAVA_HOME=$(dirname $(dirname $(readlink -f $(which javac))))"
       }
     }
     stage("Dependencies") {


### PR DESCRIPTION
In #145, The Jenkins job failed because the `JAVA_HOME` is not set.

According to [maven startup script](https://github.com/apache/maven/blob/master/apache-maven/src/assembly/shared/validate.cmd#L23), we need to set up the `JAVA_HOME` to the directory where we install the JDK