### PR TITLE
[SDFAB-612] Cluster not ready when using recent tost master images

### DIFF
--- a/app/app/src/main/java/org/omecproject/up4/impl/DistributedUp4Store.java
+++ b/app/app/src/main/java/org/omecproject/up4/impl/DistributedUp4Store.java
@@ -57,7 +57,7 @@ public class DistributedUp4Store implements Up4Store {
     private EventuallyConsistentMapListener<ImmutablePair<ImmutableByteSequence, Integer>, Ip4Address>
             farIdToUeAddrListener;
     // Local, reversed copy of farIdToUeAddrMapper for reverse lookup
-    protected Map<Ip4Address, ImmutablePair<ImmutableByteSequence, Integer>> ueAddrToFarId;
+    protected Map<Ip4Address, ImmutablePair<ImmutableByteSequence, Integer>> ueAddrToFarId = Maps.newConcurrentMap();
 
     @Activate
     protected void activate() {
@@ -79,7 +79,6 @@ public class DistributedUp4Store implements Up4Store {
         farIdToUeAddrListener = new FarIdToUeAddrMapListener();
         farIdToUeAddr.addListener(farIdToUeAddrListener);
 
-        ueAddrToFarId = Maps.newConcurrentMap();
         farIdToUeAddr.entrySet().forEach(entry -> ueAddrToFarId.put(entry.getValue(), entry.getKey()));
 
         log.info("Started");


### PR DESCRIPTION
Initialize the local cache before adding the map listener to prevent npe which are caused by events delivered during the bootstrap process of the EC map