### PR TITLE
[SDFAB-621] Add UPF data plane lazy setup

### DIFF
--- a/app/app/src/main/java/org/omecproject/up4/impl/Up4DeviceManager.java
+++ b/app/app/src/main/java/org/omecproject/up4/impl/Up4DeviceManager.java
@@ -252,10 +252,8 @@ public class Up4DeviceManager extends AbstractListenerManager<Up4Event, Up4Event
      * Asserts that UPF data plane is ready and try a lazy setup if possible.
      * This doesn't mean that all UPF physical devices are available, but only
      * that we called the init() method on all UPF programmable.
-     *
-     * @return True if UPF data plane can be programmed, False otherwise
      */
-    private boolean assertUpfIsReady() {
+    private void assertUpfIsReady() {
         if (!upfInitialized.get()) {
             if (this.config == null) {
                 throw new IllegalStateException(
@@ -291,7 +289,6 @@ public class Up4DeviceManager extends AbstractListenerManager<Up4Event, Up4Event
                 throw new IllegalStateException("UPF data plane not initialized after lazy setup!");
             }
         }
-        return true;
     }
 
     @Override


### PR DESCRIPTION
Do a lazy setup of UPF physical devices when checking if the data plane is ready. This is called upon every UP4 P4RT RPC from the UP4 north component or CLI.
This is needed because we noticed during ONOS reboot that the events that trigger the setup of the physical devices might come before the P4RT client is created. The P4RT client, however, is needed to call the `setupBehaviour` on the UpfProgrammable driver behavior.