### PR TITLE
[SDFAB-803] UE traffic was routed to default gateway

### DIFF
--- a/app/app/src/main/java/org/omecproject/up4/impl/Up4DeviceManager.java
+++ b/app/app/src/main/java/org/omecproject/up4/impl/Up4DeviceManager.java
@@ -868,6 +868,7 @@ public class Up4DeviceManager extends AbstractListenerManager<Up4Event, Up4Event
                 .setNotifyFlag(far.notifies())
                 .setBufferFlag(true)
                 .setTunnel(dbufTunnel)
+                .setDropFlag(dbufTunnel == null)
                 .build();
     }
 


### PR DESCRIPTION
`Up4DeviceManager` was not setting the drop flag when the `dbufTunnel` is null and the traffic was wrongly forwarded in the pipeline. Since there is no match for the UE subnet in the routing table, the default route is picked.