### PR TITLE
[IGNORE]Test p4rt-smoke.xml

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -161,7 +161,7 @@ pipeline {
 void runSTCSmokeTest(String topo) {
   dir("${env.WORKSPACE}/up4/scenarios") {
     sh "make reset"
-    sh "TOPO=${topo} make smoke.xml stcColor=false stcDumpLogs=true"
+    sh "TOPO=${topo} make p4rt-smoke.xml stcColor=false stcDumpLogs=true"
   }
 }
 


### PR DESCRIPTION
Please don't care about this PR. It was open to test a CI change, running `p4rt-smoke.xml` instead of `smoke.xml`