### PR TITLE
Add timeout to Jenkinsfile

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
     label "${params.buildNode}"
   }
   options {
-    timeout(time: 20, unit: 'MINUTES')
+    timeout(time: 30, unit: 'MINUTES')
   }
 
   environment {


### PR DESCRIPTION
Timeouts defined through JJB templates won't apply in declarative pipeline.

PR's aim is to define and set a global timeout for Jenkins' jobs directly in Jenkinsfile. 