### PR TITLE
Fix dynamic PSC enabled changes

### DIFF
--- a/app/app/src/main/java/org/omecproject/up4/impl/Up4DeviceManager.java
+++ b/app/app/src/main/java/org/omecproject/up4/impl/Up4DeviceManager.java
@@ -333,6 +333,8 @@ public class Up4DeviceManager extends AbstractListenerManager<Up4Event, Up4Event
                 // be small intervals without a master and interfaces pushed could be lost. Having this call here should
                 // provide more guarantee as this is also called when the pipeline is ready
                 ensureInterfacesInstalled();
+                // Update PSC configuration if needed
+                applyPscEncap();
             } else if (!upfDevices.contains(deviceId)) {
                 log.warn("UPF {} is not in the configuration!", deviceId);
             } else if (deviceService.getDevice(deviceId) == null) {
@@ -561,7 +563,6 @@ public class Up4DeviceManager extends AbstractListenerManager<Up4Event, Up4Event
             upfDevices.addAll(upfDeviceIds);
             upfDeviceIds.forEach(this::setUpfDevice);
             updateDbufTunnel();
-            applyPscEncap();
         } else {
             log.error("Invalid UP4 config loaded! Cannot set up UPF.");
         }


### PR DESCRIPTION
Apply PSC changes only when the UPF is ready and initialized.