### PR TITLE
Update email address for post-merge build failures

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -170,7 +170,7 @@ pipeline {
           emailext(
               subject: "[${env.JOB_NAME}] ${currentBuild.currentResult}: ${params.sha1}",
               body: "Check results at ${env.BUILD_URL}",
-              to: "carmelo@opennetworking.org"
+              to: "daniele@opennetworking.org"
           )
         }
       }


### PR DESCRIPTION
To inform the main project maintainer. In the future, we might consider creating a Google group so we can easily manage delivery to multiple people.