### PR TITLE
Compute only PENDING_ADD and ADDED rules in reconciliation cycle

### DIFF
--- a/app/app/src/main/java/org/omecproject/up4/impl/Up4DeviceManager.java
+++ b/app/app/src/main/java/org/omecproject/up4/impl/Up4DeviceManager.java
@@ -48,6 +48,7 @@ import org.onosproject.net.flow.FlowRuleEvent;
 import org.onosproject.net.flow.FlowRuleListener;
 import org.onosproject.net.flow.FlowRuleOperations;
 import org.onosproject.net.flow.FlowRuleService;
+import org.onosproject.net.flow.FlowEntry.FlowEntryState;
 import org.onosproject.net.pi.service.PiPipeconfEvent;
 import org.onosproject.net.pi.service.PiPipeconfListener;
 import org.onosproject.net.pi.service.PiPipeconfService;
@@ -1193,6 +1194,7 @@ public class Up4DeviceManager extends AbstractListenerManager<Up4Event, Up4Event
                 Set<FlowRule> leaderRules =
                     StreamSupport.stream(flowRuleService.getFlowEntries(leaderUpfDevice).spliterator(), false)
                         .filter(r -> getLeaderUpfProgrammable().fromThisUpf(r))
+                        .filter(r -> r.state() == FlowEntryState.PENDING_ADD || r.state() == FlowEntryState.ADDED)
                         .collect(Collectors.toSet());
 
                 // Replace the follower's device id with leader's id,
@@ -1200,6 +1202,7 @@ public class Up4DeviceManager extends AbstractListenerManager<Up4Event, Up4Event
                 Set<FlowRule> followerRules =
                     StreamSupport.stream(flowRuleService.getFlowEntries(deviceId).spliterator(), false)
                         .filter(r -> upfProg.fromThisUpf(r))
+                        .filter(r -> r.state() == FlowEntryState.PENDING_ADD || r.state() == FlowEntryState.ADDED)
                         .map(r -> copyFlowRuleForDevice(r, leaderUpfDevice))
                         .collect(Collectors.toSet());
 


### PR DESCRIPTION
Apply a new filter that accepts only PENDING_ADD and ADDED rules in the reconciliation cycle.
Otherwise, we may re-apply PENDING_DELETE rules to follower UPFs. 