### PR TITLE
Revert "[SDFAB-1049] Use go based mock-smf (#237)"

### DIFF
--- a/.env.devel
+++ b/.env.devel
@@ -5,7 +5,6 @@
 # integration testing of in-development components.
 
 PFCP_AGENT_IMAGE=omecproject/upf-epc-pfcpiface:master-latest
-PFCPSIM_IMAGE=opennetworking/pfcpsim:latest
 ONOS_IMAGE=opennetworking/sdfabric-onos:master
 DBUF_IMAGE=opennetworking/dbuf:latest
 MN_STRATUM_IMAGE=opennetworking/mn-stratum:latest

--- a/.env.stable
+++ b/.env.stable
@@ -4,7 +4,6 @@
 
 PFCP_AGENT_IMAGE=omecproject/upf-epc-pfcpiface:master-b78ba47
 ONOS_IMAGE=opennetworking/sdfabric-onos:master-2022-02-18
-PFCPSIM_IMAGE=opennetworking/pfcpsim:19a69dc4
 ATOMIX_IMAGE=atomix/atomix:3.1.9
 DBUF_IMAGE=opennetworking/dbuf:1.0.0
 MN_STRATUM_IMAGE=opennetworking/mn-stratum:latest@sha256:5f53ea1c5784ca89753e7a23ae64d52fe39371f9e0ac218883bc28864c37e373

--- a/scenarios/docker-compose.yml
+++ b/scenarios/docker-compose.yml
@@ -18,14 +18,18 @@ services:
     expose:
       - 8805
   mock-smf:
-    image: ${PFCPSIM_IMAGE}
+    build:
+      context: ./topo
+      dockerfile: Dockerfile.scapy
     hostname: mock-smf
     container_name: mock-smf
     tty: true
+    stdin_open: true
     volumes:
       - ./tmp:/tmp
       - ./topo:/topo
       - ./bin:/up4/bin
+    entrypoint: "/bin/sh"
   p4rt:
     build:
       context: ./topo

--- a/scenarios/pfcp-agent-failure.xml
+++ b/scenarios/pfcp-agent-failure.xml
@@ -7,9 +7,9 @@
     <group name="Pfcp-Agent-Failure">
         <group name="AF-Setup-Fwd">
             <step name="AF-Create-Session"
-                  exec="${DOCKER_COMPOSE_CMD} exec -T mock-smf pfcpctl -c create --ue-pool 17.0.0.0/24 --gnb-addr 140.0.100.1"/>
+                  exec="mock-smf-cmd create"/>
             <step name="AF-Modify-Session" requires="^" delay="1"
-                  exec="${DOCKER_COMPOSE_CMD} exec -T mock-smf pfcpctl -c modify --ue-pool 17.0.0.0/24 --gnb-addr 140.0.100.1"/>
+                  exec="mock-smf-cmd modify"/>
         </group>
 
         <step name="AF-Check-Flows-1" requires="AF-Setup-Fwd" delay="2"
@@ -26,12 +26,12 @@
 
         <!-- Reboot SMF because it probably doesn't react well to failures -->
         <group name="AF-Restart-Smf" requires="~AF-Check-Flows-2">
-            <step name="AF-Kill-Smf" delay="1"
-                  exec="${DOCKER_COMPOSE_CMD} restart mock-smf"/>
-            <step name="AF-Configure-Smf" requires="AF-Kill-Smf"
-                  exec="${DOCKER_COMPOSE_CMD} exec -T mock-smf pfcpctl -c configure --n3-addr 140.0.0.1 --remote-peer pfcp-agent"/>
-            <step name="AF-Associate-Smf" requires="AF-Configure-Smf"
-                  exec="${DOCKER_COMPOSE_CMD} exec -T mock-smf pfcpctl -c associate"/>
+            <step name="AF-Kill-Smf"
+                  exec="mock-smf-cmd kill"/>
+            <step name="AF-Start-Smf" requires="^"
+                  exec="mock-smf-cmd start"/>
+            <step name="AF-Associate-Smf" requires="^" delay="1"
+                  exec="mock-smf-cmd associate"/>
         </group>
     </group>
 </scenario>

--- a/scenarios/pfcp-app-filtering.xml
+++ b/scenarios/pfcp-app-filtering.xml
@@ -10,9 +10,9 @@
                             starts="Pfcp-Session-Create-App-Filtering-${#}"
                             ends="Pfcp-Session-App-Filtering-${#-1}">
                     <step name="Pfcp-Session-Create-App-Filtering-${#}"
-                          exec="${DOCKER_COMPOSE_CMD} exec -T mock-smf pfcpctl -c create --count 5 --baseID ${#}0 --ue-pool 17.0.${#-1}.0/24 --gnb-addr 140.0.10${#-1}.1 --sdf-filter 'permit out ip from 0.0.0.0/0 to assigned 81-81'"/>
+                          exec="mock-smf-cmd create --session-count 5 --base ${#}0 --ue-pool 17.0.${#-1}.0/24 --enb-addr 140.0.10${#-1}.1 --no-wildcard"/>
                     <step name="Pfcp-Session-App-Filtering-${#}" requires="^"
-                          exec="${DOCKER_COMPOSE_CMD} exec -T mock-smf pfcpctl -c modify --count 5 --baseID ${#}0 --ue-pool 17.0.${#-1}.0/24 --gnb-addr 140.0.10${#-1}.1"/>
+                          exec="mock-smf-cmd modify --session-count 5 --base ${#}0 --ue-pool 17.0.${#-1}.0/24 --enb-addr 140.0.10${#-1}.1 --no-wildcard"/>
                 </sequential>
             </group>
             <step name="Check-Up4-Flows-App-Filtering" requires="Pfcp-Push-App-Filtering" delay="5"
@@ -53,7 +53,7 @@
                 starts="Clear-App-Filtering-${#}"
                 ends="Clear-App-Filtering-${#-1}">
                 <step name="Clear-App-Filtering-${#}" requires="~Check-Traffic-App-Filtering-Negative,~Check-Traffic-App-Filtering-Positive"
-                      exec="${DOCKER_COMPOSE_CMD} exec -T mock-smf pfcpctl -c delete --count 5 --baseID ${#}0"/>
+                      exec="mock-smf-cmd delete --session-count 5 --base ${#}0 --ue-pool 17.0.${#-1}.0/24 --enb-addr 140.0.10${#-1}.1 --no-wildcard"/>
             </sequential>
         </group>
     </group>

--- a/scenarios/pfcp-buffering.xml
+++ b/scenarios/pfcp-buffering.xml
@@ -12,7 +12,7 @@
                             starts="Pfcp-Buffer-Session-Create-${#}"
                             ends="Pfcp-Buffer-Session-Create-${#-1}">
                     <step name="Pfcp-Buffer-Session-Create-${#}" requires="Push-Netcfg-Dbuf" delay="5"
-                          exec="${DOCKER_COMPOSE_CMD} exec -T mock-smf pfcpctl -c create --count 5 --baseID ${#}0 --ue-pool 17.0.${#-1}.0/24 --gnb-addr 140.0.10${#-1}.1"/>
+                          exec="mock-smf-cmd create --session-count 5 --base ${#}0 --ue-pool 17.0.${#-1}.0/24 --enb-addr 140.0.10${#-1}.1"/>
                 </sequential>
             </group>
             <step name="Check-Up4-Flows-Buff-Create" requires="Pfcp-Push-Buff-Create" delay="5"
@@ -35,7 +35,7 @@
                             starts="Pfcp-Buffer-Session-Modify-${#}"
                             ends="Pfcp-Buffer-Session-Modify-${#-1}">
                     <step name="Pfcp-Buffer-Session-Modify-${#}" requires="Check-Traffic-Buff-Drop-DL" delay="5"
-                          exec="${DOCKER_COMPOSE_CMD} exec -T mock-smf pfcpctl -c modify --count 5 --baseID ${#}0 --ue-pool 17.0.${#-1}.0/24 --gnb-addr 140.0.10${#-1}.1"/>
+                          exec="mock-smf-cmd modify --session-count 5 --base ${#}0 --ue-pool 17.0.${#-1}.0/24 --enb-addr 140.0.10${#-1}.1"/>
                 </sequential>
             </group>
             <step name="Check-Up4-Flows-Buff-Modify" requires="Pfcp-Push-Buff-Modify" delay="5"
@@ -49,7 +49,7 @@
                             starts="Pfcp-Buffer-Session-Buffer-${#}"
                             ends="Pfcp-Buffer-Session-Buffer-${#-1}">
                     <step name="Pfcp-Buffer-Session-Buffer-${#}" requires="Pfcp-Set-Buff-Modify" delay="5"
-                          exec="${DOCKER_COMPOSE_CMD} exec -T mock-smf pfcpctl -c modify --count 5 --buffer --notifycp --baseID ${#}0 --ue-pool 17.0.${#-1}.0/24 --gnb-addr 140.0.10${#-1}.1"/>
+                          exec="mock-smf-cmd modify --buffer --notifycp --session-count 5 --base ${#}0 --ue-pool 17.0.${#-1}.0/24 --enb-addr 140.0.10${#-1}.1"/>
                 </sequential>
             </group>
             <step name="Check-Up4-Flows-Buff-Buffer" requires="Pfcp-Push-Buff-Buffer" delay="5"
@@ -71,7 +71,7 @@
                 <step name="Downlink-Enb-Recv-Gtp-Buff-${#}" requires="Verify-First-Buffer-${#}"
                       exec="mn-cmd ${ENODEB#} traffic.py recv-gtp -t 60 --no-verify-teid --flow-count 5 --teid-base ${#}0 --ue-pool 17.0.${#-1}.0/24 --enb-addr 140.0.10${#-1}.1"/>
                 <step name="Pfcp-Set-Fwd-After-Buff-${#}" requires="Verify-First-Buffer-${#}" delay="5"
-                      exec="${DOCKER_COMPOSE_CMD} exec -T mock-smf pfcpctl -c modify --count 5 --baseID ${#}0 --ue-pool 17.0.${#-1}.0/24 --gnb-addr 140.0.10${#-1}.1"/>
+                      exec="mock-smf-cmd modify --session-count 5 --sleep-time 1 --base ${#}0 --ue-pool 17.0.${#-1}.0/24 --enb-addr 140.0.10${#-1}.1"/>
                 <step name="Check-Drain-Started-${#}" requires="Pfcp-Set-Fwd-After-Buff-${#}" delay="5"
                       exec="docker-log-grep ${ODI} 'Started dbuf drain for 17.0.${#-1}' 5"/>
                 <step name="Check-Drain-Completed-${#}" requires="Pfcp-Set-Fwd-After-Buff-${#}" delay="5"
@@ -84,7 +84,7 @@
                             starts="Pfcp-Unset-Fwd-After-Buff-${#}"
                             ends="Pfcp-Unset-Fwd-After-Buff-${#-1}">
                     <step name="Pfcp-Unset-Fwd-After-Buff-${#}"
-                          exec="${DOCKER_COMPOSE_CMD} exec -T mock-smf pfcpctl -c delete --count 5 --baseID ${#}0"/>
+                          exec="mock-smf-cmd delete --session-count 5 --base ${#}0 --ue-pool 17.0.${#-1}.0/24 --enb-addr 140.0.10${#-1}.1"/>
                 </sequential>
             </group>
             <step name="Check-Up4-Flows-Fwd-After-Buff-Cleared" requires="Clear-Buff"

--- a/scenarios/pfcp-forwarding.xml
+++ b/scenarios/pfcp-forwarding.xml
@@ -10,7 +10,7 @@
                             starts="Pfcp-Session-Create-${#}"
                             ends="Pfcp-Session-Create-${#-1}">
                     <step name="Pfcp-Session-Create-${#}"
-                          exec="${DOCKER_COMPOSE_CMD} exec -T mock-smf pfcpctl -c create --count 5 --baseID ${#}0 --ue-pool 17.0.${#-1}.0/24 --gnb-addr 140.0.10${#-1}.1"/>
+                          exec="mock-smf-cmd create --session-count 5 --base ${#}0 --ue-pool 17.0.${#-1}.0/24 --enb-addr 140.0.10${#-1}.1"/>
                 </sequential>
             </group>
             <step name="Check-Up4-Flows-Fwd-Create" requires="Pfcp-Push-Fwd-Create" delay="5"
@@ -33,7 +33,7 @@
                             starts="Pfcp-Session-Modify-${#}"
                             ends="Pfcp-Session-Modify-${#-1}">
                     <step name="Pfcp-Session-Modify-${#}"
-                           exec="${DOCKER_COMPOSE_CMD} exec -T mock-smf pfcpctl -c modify --count 5 --baseID ${#}0 --ue-pool 17.0.${#-1}.0/24 --gnb-addr 140.0.10${#-1}.1"/>
+                           exec="mock-smf-cmd modify --session-count 5 --base ${#}0 --ue-pool 17.0.${#-1}.0/24 --enb-addr 140.0.10${#-1}.1"/>
                 </sequential>
             </group>
             <step name="Check-Up4-Flows-Fwd-Modify" requires="Pfcp-Push-Fwd-Modify" delay="5"
@@ -60,7 +60,7 @@
                         starts="Clear-Fwd-${#}"
                         ends="Clear-Fwd-${#-1}">
                 <step name="Clear-Fwd-${#}" requires="~Check-Traffic-Fwd"
-                      exec="${DOCKER_COMPOSE_CMD} exec -T mock-smf pfcpctl -c delete --count 5 --baseID ${#}0"/>
+                      exec="mock-smf-cmd delete --session-count 5 --base ${#}0 --ue-pool 17.0.${#-1}.0/24 --enb-addr 140.0.10${#-1}.1"/>
             </sequential>
         </group>
     </group>

--- a/scenarios/smf-failure.xml
+++ b/scenarios/smf-failure.xml
@@ -7,36 +7,32 @@
     <group name="Smf-Failure">
         <group name="SF-Setup-Fwd-1">
             <step name="SF-Create-Session-1"
-                  exec="${DOCKER_COMPOSE_CMD} exec -T mock-smf pfcpctl -c create --count 1 --baseID 1 --ue-pool 17.0.0.0/24 --gnb-addr 140.0.100.1"/>
+                  exec="mock-smf-cmd create"/>
             <step name="SF-Modify-Session-1" requires="^" delay="1"
-                  exec="${DOCKER_COMPOSE_CMD} exec -T mock-smf pfcpctl -c modify --count 1 --baseID 1 --ue-pool 17.0.0.0/24 --gnb-addr 140.0.100.1"/>
+                  exec="mock-smf-cmd modify"/>
         </group>
 
         <step name="SF-Check-Flows-1" requires="SF-Setup-Fwd-1" delay="2"
               exec="onos-cli-grep ${OCI} up4:read-flows 'UL flows=1, DL flows=1'"/>
 
         <step name="SF-Kill-Smf" requires="^"
-              exec="${DOCKER_COMPOSE_CMD} kill mock-smf"/>
+              exec="mock-smf-cmd kill"/>
 
         <step name="SF-Check-Flows-2" requires="^" delay="10"
               exec="onos-cli-grep ${OCI} up4:read-flows 'UL flows=0, DL flows=0'"/>
 
-      <group name="SF-Revive-Smf">
-            <step name="SF-Revive-Smf-1" requires="~SF-Check-Flows-2" delay="1"
-                        exec="${DOCKER_COMPOSE_CMD} up -d mock-smf"/>
-            <step name="SF-Revive-Smf-2" requires="SF-Revive-Smf-1" delay="1"
-                        exec="${DOCKER_COMPOSE_CMD} exec -T mock-smf pfcpctl -c configure --n3-addr 140.0.0.1 --remote-peer pfcp-agent"/>
-            <step name="SF-Revive-Smf-3" requires="SF-Revive-Smf-1"
-                        exec="${DOCKER_COMPOSE_CMD} exec -Td mock-smf tcpdump -i eth0 -w tmp/pcaps/mock-smf_$(date +%H:%M:%S).pcap"/>
-            <step name="SF-Revive-Smf-4" requires="SF-Revive-Smf-2" delay="1"
-                        exec="${DOCKER_COMPOSE_CMD} exec -T mock-smf pfcpctl -c associate"/>
-      </group>
+        <group name="SF-Revive-Smf" requires="~SF-Check-Flows-2">
+            <step name="SF-Start-Smf"
+                  exec="mock-smf-cmd start"/>
+            <step name="SF-Associate-Smf" requires="^" delay="1"
+                  exec="mock-smf-cmd associate"/>
+        </group>
 
         <group name="SF-Setup-Fwd-2" requires="SF-Revive-Smf">
             <step name="SF-Create-Session-2"
-                  exec="${DOCKER_COMPOSE_CMD} exec -T mock-smf pfcpctl -c create --ue-pool 17.0.0.0/24 --gnb-addr 140.0.100.1"/>
+                  exec="mock-smf-cmd create"/>
             <step name="SF-Modify-Session-2" requires="^" delay="1"
-                  exec="${DOCKER_COMPOSE_CMD} exec -T mock-smf pfcpctl -c modify --ue-pool 17.0.0.0/24 --gnb-addr 140.0.100.1"/>
+                  exec="mock-smf-cmd modify"/>
         </group>
 
         <step name="SF-Check-Flows-3" requires="SF-Setup-Fwd-2" delay="2"
@@ -45,18 +41,18 @@
         <group name="SF-Check-Fwding" requires="SF-Check-Flows-3">
             <!-- Downlink -->
             <step name="SF-Downlink-Enb-Recv-Gtp-Fwd"
-                  exec="mn-cmd ${ENODEB1} traffic.py recv-gtp --teid-base 1 -t 10"/>
+                  exec="mn-cmd ${ENODEB1} traffic.py recv-gtp -t 10"/>
             <step name="SF-Downlink-Pdn-Send-Udp-Fwd" requires="SF-Check-Flows-3" delay="5"
-                  exec="mn-cmd pdn traffic.py send-udp --teid-base 1 -c 10"/>
+                  exec="mn-cmd pdn traffic.py send-udp -c 10"/>
             <!-- Uplink -->
             <step name="SF-Uplink-Pdn-Recv-Udp-Fwd"
-                  exec="mn-cmd pdn traffic.py recv-udp --teid-base 1 -t 10"/>
+                  exec="mn-cmd pdn traffic.py recv-udp -t 10"/>
             <step name="SF-Uplink-Enb-Send-Gtp-Fwd" delay="5"
-                  exec="mn-cmd ${ENODEB1} traffic.py send-gtp --teid-base 1 -c 10"/>
+                  exec="mn-cmd ${ENODEB1} traffic.py send-gtp -c 10"/>
         </group>
 
         <step name="SF-Clear-Flows" requires="~SF-Check-Fwding"
-              exec="${DOCKER_COMPOSE_CMD} exec -T mock-smf pfcpctl -c delete"/>
+              exec="mock-smf-cmd delete"/>
 
         <step name="SF-Check-Flows-4" requires="^" delay="2"
               exec="onos-cli-grep ${OCI} up4:read-flows 'UL flows=0, DL flows=0'"/>

--- a/scenarios/smf-setup.xml
+++ b/scenarios/smf-setup.xml
@@ -4,13 +4,12 @@
   -->
 <scenario name="smf-setup" description="Mock SMF setup">
     <group name="Smf-Setup">
-
-        <step name="Mock-Smf-Configure"
-              exec="${DOCKER_COMPOSE_CMD} exec -T mock-smf pfcpctl -c configure --n3-addr 140.0.0.1 --remote-peer pfcp-agent"/>
-        <step name="Mock-Smf-Associate" requires="Mock-Smf-Configure"
-              exec="${DOCKER_COMPOSE_CMD} exec -T mock-smf pfcpctl -c associate"/>
-        <step name="Mock-Smf-Start-Sniffer" requires="Mock-Smf-Configure"
-              exec="${DOCKER_COMPOSE_CMD} exec -Td mock-smf tcpdump -i eth0 -w tmp/mock-smf_$(date +%H:%M:%S).pcap"/>
+        <step name="Mock-Smf-Start"
+              exec="mock-smf-cmd start"/>
+        <step name="Check-Mock-Smf-Survived-Start" requires="^"
+              exec="mock-smf-cmd check"/>
+        <step name="Mock-Smf-Associate" requires="^"
+              exec="mock-smf-cmd associate"/>
         <step name="Check-Pfcp-Agent-Survived-Start" requires="^" delay="1"
               exec="pfcp-agent-check-alive"/>
         <step name="Check-Up4-N3-Interface" requires="^"

--- a/scenarios/smf-teardown.xml
+++ b/scenarios/smf-teardown.xml
@@ -5,7 +5,7 @@
 <scenario name="smf-teardown" description="Mock SMF teardown">
     <group name="Smf-Teardown">
         <step name="Mock-Smf-Stop"
-              exec="${DOCKER_COMPOSE_CMD} exec -T mock-smf pfcpctl -c disassociate"/>
+              exec="mock-smf-cmd stop"/>
         <step name="Check-Pfcp-Agent-Survived-Teardown" requires="~Mock-Smf-Stop"
               exec="pfcp-agent-check-alive"/>
         <step name="Check-No-Flows-After-Pfcp-Teardown" requires="Mock-Smf-Stop"


### PR DESCRIPTION
This reverts commit b340f388344d66103969d3ae09c8c646b148da83. We noticed the new go-based mock-smf causes intermittent failures in STC tests.