### PR TITLE
Get cleaner logs. Run maven in quiet mode

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -54,7 +54,7 @@ build: _build_resources
 # ci-verify is a build profile specified in onos-dependencies's pom.xml
 # It's used to run javadoc validation and other checks that should not
 # run on local build, but during CI.
-build-ci: MVN_FLAGS := -Pci-verify -Pcoverage
+build-ci: MVN_FLAGS := -B -q -Pci-verify -Pcoverage
 build-ci: local-build
 
 clean:

--- a/app/Makefile
+++ b/app/Makefile
@@ -11,7 +11,7 @@ CURRENT_DIR              := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
 # but allow passing a directory, e.g., local ~/.m2
 mvn_cache_docker_volume := mvn-cache-up4
 MVN_CACHE ?= ${mvn_cache_docker_volume}
-MVN_FLAGS ?= -B
+MVN_FLAGS ?= -q
 
 onos_tools_dir := $(abspath ${CURRENT_DIR}/../scenarios/onos/tools/package/runtime/bin)
 

--- a/app/Makefile
+++ b/app/Makefile
@@ -11,7 +11,7 @@ CURRENT_DIR              := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
 # but allow passing a directory, e.g., local ~/.m2
 mvn_cache_docker_volume := mvn-cache-up4
 MVN_CACHE ?= ${mvn_cache_docker_volume}
-MVN_FLAGS ?= -q
+MVN_FLAGS ?= -q -B
 
 onos_tools_dir := $(abspath ${CURRENT_DIR}/../scenarios/onos/tools/package/runtime/bin)
 

--- a/scenarios/Makefile
+++ b/scenarios/Makefile
@@ -74,7 +74,7 @@ onos-test:
 stc-dev-build:
 	rm -rf /tmp/onos-stc
 	cd /tmp && git clone -b quotes --depth 1 https://github.com/opennetworkinglab/onos-stc.git
-	cd /tmp/onos-stc && mvn -B -Dmaven.test.skip=true install
+	cd /tmp/onos-stc && mvn -q -Dmaven.test.skip=true install
 
 pull: ./tmp/.env.docker
 	${DOCKER_COMPOSE_CMD} pull

--- a/scenarios/Makefile
+++ b/scenarios/Makefile
@@ -74,7 +74,7 @@ onos-test:
 stc-dev-build:
 	rm -rf /tmp/onos-stc
 	cd /tmp && git clone -b quotes --depth 1 https://github.com/opennetworkinglab/onos-stc.git
-	cd /tmp/onos-stc && mvn -Dmaven.test.skip=true install
+	cd /tmp/onos-stc && mvn -B -Dmaven.test.skip=true install
 
 pull: ./tmp/.env.docker
 	${DOCKER_COMPOSE_CMD} pull
@@ -139,4 +139,3 @@ versions: ./tmp/.env.docker
     docker inspect $${PFCP_AGENT_IMAGE} | jq -r '.[0].Config.Labels' && \
     echo $${MN_STRATUM_IMAGE} && \
     docker inspect $${MN_STRATUM_IMAGE} | jq -r '.[0].Config.Labels'
-

--- a/scenarios/Makefile
+++ b/scenarios/Makefile
@@ -74,7 +74,7 @@ onos-test:
 stc-dev-build:
 	rm -rf /tmp/onos-stc
 	cd /tmp && git clone -b quotes --depth 1 https://github.com/opennetworkinglab/onos-stc.git
-	cd /tmp/onos-stc && mvn -q -Dmaven.test.skip=true install
+	cd /tmp/onos-stc && mvn -q -B -Dmaven.test.skip=true install
 
 pull: ./tmp/.env.docker
 	${DOCKER_COMPOSE_CMD} pull


### PR DESCRIPTION
Further clean logs. Remove all the useless logs about downloading packages. `-q` along with `-B` Will make maven report only warnings and errors.