### PR TITLE
[DO-NOT-MERGE] Use docker compose v2 APIs and make STCs runnable with Rancher Desktop

### DIFF
--- a/scenarios/Makefile
+++ b/scenarios/Makefile
@@ -8,7 +8,7 @@ CURRENT_DIR := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
 UP4_ROOT           := $(abspath $(CURRENT_DIR)/..)
 ONOS_TEST          := $(CURRENT_DIR)/onos-test
 SCENARIOS          := *.xml
-DOCKER_COMPOSE_CMD := docker-compose --env-file ./tmp/.env.docker
+DOCKER_COMPOSE_CMD := docker compose --env-file ./tmp/.env.docker
 CURRENT_USER       := $(shell id -u):$(shell id -g)
 
 # Set to devel to use in-development versions of components

--- a/scenarios/bin/docker-compose-up
+++ b/scenarios/bin/docker-compose-up
@@ -1,0 +1,38 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2022-present Open Networking Foundation <info@opennetworking.org>
+# SPDX-License-Identifier: Apache-2.0
+
+# Run multiple times docker-compose up. If it fails, teardown and retry.
+# This is required due to a bug in Rancher Desktop.
+# See: https://github.com/rancher-sandbox/rancher-desktop/issues/1209
+
+teardown () {
+  ${DOCKER_COMPOSE_CMD} down -t0 --remove-orphans && sleep 1
+  return $?
+}
+check_logs () {
+  ${DOCKER_COMPOSE_CMD} logs onos1 | grep "[EventAdminConfigurationNotifier] Sending Event Admin notification" && \
+    ${DOCKER_COMPOSE_CMD} logs onos2 | grep "[EventAdminConfigurationNotifier] Sending Event Admin notification" && \
+    ${DOCKER_COMPOSE_CMD} logs onos3 | grep "[EventAdminConfigurationNotifier] Sending Event Admin notification"
+  return $?
+}
+for _ in {1..5}; do
+  ${DOCKER_COMPOSE_CMD} up -d
+  if [ $? -ne 0 ]; then
+    teardown
+  else
+    # let's give ONOS some time to start and ensure ONOS has correctly started
+    sleep 5
+    for _ in {1..10}; do
+      check_logs && break || echo "FAILED" && sleep 1
+    done
+    check_logs
+    if [ $? -ne 0 ]; then
+      teardown
+    else
+      exit 0
+    fi
+  fi
+done
+
+exit 1

--- a/scenarios/bin/docker-log-grep
+++ b/scenarios/bin/docker-log-grep
@@ -11,7 +11,7 @@ if [ -z "$findCount" ]; then
 fi
 foundCount=0
 for _ in {1..60}; do
-    foundCount=$(docker-compose logs "$container" | grep "$findString" | wc -l)
+    foundCount=$(${DOCKER_COMPOSE_CMD} logs "$container" | grep "$findString" | wc -l)
     if [ "$foundCount" -ge "$findCount" ]; then
         echo "Found $foundCount occurrences of search string. Success!"
         exit 0

--- a/scenarios/bin/mock-smf-cmd
+++ b/scenarios/bin/mock-smf-cmd
@@ -8,8 +8,8 @@ imgName="mock-smf"
 logFile="tmp/mock-smf.log"
 pcapFile="tmp/mock-smf.pcap"
 agentName="pfcp-agent"
-# STC doesn't allocate a TTY so without -T docker-compose exec will fail
-dockerExec="docker-compose exec -T $imgName"
+# STC doesn't allocate a TTY so without -T ${DOCKER_COMPOSE_CMD} exec will fail
+dockerExec="${DOCKER_COMPOSE_CMD} exec -T $imgName"
 
 echo "Provided command is $1"
 if [ "$1" = "start" ]; then

--- a/scenarios/bin/onos-check-logs
+++ b/scenarios/bin/onos-check-logs
@@ -5,11 +5,11 @@
 # Checks the onos log for errors
 container=${1:-$ODI}
 regex='ERROR|Exception|Error'
-errors=$(docker-compose logs "${container}" | grep -E -c ${regex})
+errors=$(${DOCKER_COMPOSE_CMD} logs "${container}" | grep -E -c ${regex})
 
 if [ "$errors" -eq "0" ]; then
    exit 0;
 else
-  docker-compose logs "${container}" | grep -E ${regex}
+  ${DOCKER_COMPOSE_CMD} logs "${container}" | grep -E ${regex}
   exit 1;
 fi

--- a/scenarios/bin/onos-user-key
+++ b/scenarios/bin/onos-user-key
@@ -15,4 +15,4 @@ key=${3:-$(cut -d\  -f2 ~/.ssh/id_rsa.pub)}
 # /root/onos/bin/onos-user-key at the end calls ssh-keygen which is missing in the container, hence
 # causing a non-zero exit status. However, adding the key to karaf properties should always be
 # successful, hence "| true".
-docker-compose exec -T "${container}" bash -c "/root/onos/bin/onos-user-key $user $key | true"
+${DOCKER_COMPOSE_CMD} exec -T "${container}" bash -c "/root/onos/bin/onos-user-key $user $key | true"

--- a/scenarios/bin/onos-wait-for-start
+++ b/scenarios/bin/onos-wait-for-start
@@ -4,8 +4,8 @@
 
 # Wait until ApplicationManager is available
 for _ in {1..60}; do
-    docker-compose logs "$1" | grep "ApplicationManager.*Started" && break || sleep 1
+    ${DOCKER_COMPOSE_CMD} logs "$1" | grep "ApplicationManager.*Started" && break || sleep 1
 done
 
-docker-compose logs "$1" | grep "ApplicationManager.*Started"
+${DOCKER_COMPOSE_CMD} logs "$1" | grep "ApplicationManager.*Started"
 

--- a/scenarios/bin/pfcp-agent-wait-for-start
+++ b/scenarios/bin/pfcp-agent-wait-for-start
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 for _ in {1..30}; do
-    docker-compose ps | grep "pfcp-agent" && \
-        docker-compose logs pfcp-agent | grep "listening for new PFCP connections" \
+    ${DOCKER_COMPOSE_CMD} ps | grep "pfcp-agent" && \
+        ${DOCKER_COMPOSE_CMD} logs pfcp-agent | grep "listening for new PFCP connections" \
         && exit 0 || sleep 1
 done
 exit 1

--- a/scenarios/setup.xml
+++ b/scenarios/setup.xml
@@ -4,7 +4,7 @@
   -->
 <scenario name="setup" description="Environment setup">
     <group name="Setup">
-        <step name="Docker-Compose-Up" exec="${DOCKER_COMPOSE_CMD} up -d"/>
+        <step name="Docker-Compose-Up" exec="docker-compose-up"/>
 
         <step name="Mn-Wait-For-Start-Dbuf"
               exec="file-grep tmp/dbuf_dbuf1.log 'Listening for gRPC requests'"


### PR DESCRIPTION
Still `pfcp-buffering` tends to fail. I see many packets bouncing between the switch and dbuf during the drain phase, maybe it's due to the fact that we drain without making sure the switch state has changed to forward traffic instead of buffering.