### PR TITLE
[SDFAB-1176] UP4 CLI command to show average tput for UE sessions

### DIFF
--- a/app/app/src/main/java/org/omecproject/up4/cli/FlowsStatsCommand.java
+++ b/app/app/src/main/java/org/omecproject/up4/cli/FlowsStatsCommand.java
@@ -5,6 +5,7 @@
 package org.omecproject.up4.cli;
 
 import com.google.common.collect.Maps;
+import org.apache.karaf.shell.api.action.Argument;
 import org.apache.karaf.shell.api.action.Command;
 import org.apache.karaf.shell.api.action.lifecycle.Service;
 import org.omecproject.up4.impl.Up4AdminService;
@@ -23,44 +24,88 @@ import java.util.Map;
 public class FlowsStatsCommand extends AbstractShellCommand {
 
     private static final String SEPARATOR = "-".repeat(40);
-    private static final int SLEEP_TIME_MS = 200;
+    private static final int DEFAULT_SLEEP_TIME = 2000; // 2 seconds
+
+    @Argument(index = 0, name = "sleep-time",
+            description = "Time between counter reads",
+            required = false)
+    int sleepTimeMs = DEFAULT_SLEEP_TIME;
+
+    // Add completer?
+    @Argument(index = 1, name = "ue-session-id",
+            description = "UE Session ID (IPv4 UE address)",
+            required = false)
+    String ueSessionId = null;
 
     @Override
     protected void doExecute() throws Exception {
         Up4AdminService adminService = get(Up4AdminService.class);
+        Ip4Address ueAddr = ueSessionId != null ? Ip4Address.valueOf(ueSessionId) : null;
 
         Map<Ip4Address, UpfCounter> beforeDownlink = Maps.newHashMap();
-        adminService.getDownlinkFlows().forEach(dlUpfFlow -> {
-            beforeDownlink.put(dlUpfFlow.getSession().ueAddress(), dlUpfFlow.getCounter());
-        });
+        adminService.getDownlinkFlows().stream()
+                .filter(upfFlow -> ueAddr == null || ueAddr.equals(upfFlow.getTermination().ueSessionId()))
+                .forEach(
+                        dlUpfFlow -> beforeDownlink.compute(
+                                dlUpfFlow.getTermination().ueSessionId(),
+                                (key, value) -> (value == null) ?
+                                        dlUpfFlow.getCounter() :
+                                        sumUpfCounters(value, dlUpfFlow.getCounter())
+                        )
+                );
 
         Map<Ip4Address, UpfCounter> beforeUplink = Maps.newHashMap();
-        adminService.getUplinkFlows().forEach(ulUpfFlow -> {
-            beforeUplink.put(ulUpfFlow.getTermination().ueSessionId(), ulUpfFlow.getCounter());
-        });
-        Thread.sleep(SLEEP_TIME_MS);
+        adminService.getUplinkFlows().stream()
+                .filter(upfFlow -> ueAddr == null || ueAddr.equals(upfFlow.getTermination().ueSessionId()))
+                .forEach(
+                        ulUpfFlow -> beforeUplink.compute(
+                                ulUpfFlow.getTermination().ueSessionId(),
+                                (key, value) -> (value == null) ?
+                                        ulUpfFlow.getCounter() :
+                                        sumUpfCounters(value, ulUpfFlow.getCounter())
+                        )
+                );
 
-        Map<Ip4Address, UpfCounter> afterDownlink = Maps.newHashMap();
-        adminService.getDownlinkFlows().forEach(dlUpfFlow -> {
-            afterDownlink.put(dlUpfFlow.getSession().ueAddress(), dlUpfFlow.getCounter());
-        });
-
-        Map<Ip4Address, UpfCounter> afterUplink = Maps.newHashMap();
-        adminService.getUplinkFlows().forEach(ulUpfFlow -> {
-            afterUplink.put(ulUpfFlow.getTermination().ueSessionId(), ulUpfFlow.getCounter());
-        });
-
-        print(SEPARATOR);
-        if (!(beforeDownlink.keySet().equals(beforeUplink.keySet()) &&
-                beforeDownlink.keySet().equals(afterUplink) &&
-                beforeDownlink.keySet().equals(afterDownlink))) {
-            print("ERROR while reading stats!");
+        if (beforeDownlink.isEmpty() || beforeUplink.isEmpty()) {
+            print("No UE Sessions");
             return;
         }
+        Thread.sleep(sleepTimeMs);
+
+        Map<Ip4Address, UpfCounter> afterDownlink = Maps.newHashMap();
+        adminService.getDownlinkFlows().stream()
+                .filter(upfFlow -> ueAddr == null || ueAddr.equals(upfFlow.getTermination().ueSessionId()))
+                .forEach(
+                        dlUpfFlow -> afterDownlink.compute(
+                                dlUpfFlow.getTermination().ueSessionId(),
+                                (key, value) -> (value == null) ?
+                                        dlUpfFlow.getCounter() :
+                                        sumUpfCounters(value, dlUpfFlow.getCounter())
+                        )
+                );
+
+        Map<Ip4Address, UpfCounter> afterUplink = Maps.newHashMap();
+        adminService.getUplinkFlows().stream()
+                .filter(upfFlow -> ueAddr == null || ueAddr.equals(upfFlow.getTermination().ueSessionId()))
+                .forEach(
+                        ulUpfFlow -> afterUplink.compute(
+                                ulUpfFlow.getTermination().ueSessionId(),
+                                (key, value) -> (value == null) ?
+                                        ulUpfFlow.getCounter() :
+                                        sumUpfCounters(value, ulUpfFlow.getCounter())
+                        )
+                );
+
+        if (!(beforeDownlink.keySet().containsAll(beforeUplink.keySet()) &&
+                beforeDownlink.keySet().equals(afterUplink.keySet()) &&
+                beforeDownlink.keySet().equals(afterDownlink.keySet()))) {
+            print("Error while reading stats!");
+            return;
+        }
+
+        print(SEPARATOR);
         for (Ip4Address ueSessionId : beforeDownlink.keySet()) {
-            if (!beforeUplink.containsKey(ueSessionId) ||
-                    !afterDownlink.containsKey(ueSessionId) ||
-                    !afterUplink.containsKey(ueSessionId)) {
+            if (ueAddr == null || ueAddr.equals(ueSessionId)) {
                 print("UE session: " + ueSessionId.toString());
                 UpfCounter bfUl = beforeUplink.get(ueSessionId);
                 UpfCounter bfDl = beforeDownlink.get(ueSessionId);
@@ -71,38 +116,48 @@ public class FlowsStatsCommand extends AbstractShellCommand {
                 long droppedPktsDl = (afDl.getIngressPkts() - afDl.getEgressPkts()) -
                         (bfDl.getIngressPkts() - bfDl.getEgressPkts());
 
-                long txPktsUl = (afUl.getEgressPkts() - bfUl.getEgressPkts()) / SLEEP_TIME_MS;
-                long txBytesUl = (afUl.getEgressBytes() - bfUl.getEgressBytes()) / SLEEP_TIME_MS;
-                long txPktsDl = (afDl.getEgressPkts() - bfDl.getEgressPkts()) / SLEEP_TIME_MS;
-                long txBytesDl = (afDl.getEgressBytes() - bfDl.getEgressBytes()) / SLEEP_TIME_MS;
+                double txPktsUl = (afUl.getEgressPkts() - bfUl.getEgressPkts()) / (sleepTimeMs / 1000.0);
+                double txBytesUl = ((afUl.getEgressBytes() - bfUl.getEgressBytes()) * 8) / (sleepTimeMs / 1000.0);
+                double txPktsDl = (afDl.getEgressPkts() - bfDl.getEgressPkts()) / (sleepTimeMs / 1000.0);
+                double txBytesDl = ((afDl.getEgressBytes() - bfDl.getEgressBytes()) * 8) / (sleepTimeMs / 1000.0);
 
-                long rxPktsUl = (afUl.getIngressPkts() - bfUl.getIngressPkts()) / SLEEP_TIME_MS;
-                long rxBytesUl = (afUl.getIngressBytes() - bfUl.getIngressBytes()) / SLEEP_TIME_MS;
-                long rxPktsDl = (afDl.getIngressPkts() - bfDl.getIngressPkts()) / SLEEP_TIME_MS;
-                long rxBytesDl = (afDl.getIngressBytes() - bfDl.getIngressBytes()) / SLEEP_TIME_MS;
+                double rxPktsUl = (afUl.getIngressPkts() - bfUl.getIngressPkts()) / (sleepTimeMs / 1000.0);
+                double rxPktsDl = (afDl.getIngressPkts() - bfDl.getIngressPkts()) / (sleepTimeMs / 1000.0);
 
-                print("UPLINK");
-                print("    RX:  %s  %s", toReadable(rxBytesUl, "Bps"), toReadable(rxPktsUl, "pkt/s"));
-                print("    TX:  %s  %s", toReadable(txBytesUl, "Bps"), toReadable(txPktsUl, "pkt/s"));
-                print("    DROPPED:  %d", droppedPktsDl);
-                print("DOWNLINK");
-                print("    RX:  %s  %s", toReadable(rxBytesDl, "Bps"), toReadable(rxPktsDl, "pkt/s"));
-                print("    TX:  %s  %s", toReadable(txBytesDl, "Bps"), toReadable(txPktsDl, "pkt/s"));
-                print("    DROPPED:  %d", droppedPktsUl);
+                print("Uplink");
+                print("  tput: %s / %s (%.1f%% dropped)",
+                      toReadable(txBytesUl, "bps"),
+                      toReadable(txPktsUl, "pps"),
+                      rxPktsUl == 0 ? 0.0 : (droppedPktsUl / rxPktsUl) * 100.0);
+                print("Downlink");
+                print("  tput: %s / %s (%.1f%% dropped)",
+                      toReadable(txBytesDl, "bps"),
+                      toReadable(txPktsDl, "pps"),
+                      rxPktsDl == 0 ? 0.0 : (droppedPktsDl / rxPktsDl) * 100.0);
                 print(SEPARATOR);
             }
         }
     }
 
-    String toReadable(long value, String unit) {
+    private String toReadable(double value, String unit) {
         if (value < 1000) {
-            return String.format("%.1f %s", (float) value, unit);
+            return String.format("%.3f %s", value, unit);
         } else if (value < 1000000) {
-            return String.format("%.1f K%s", value / 1000.0, unit);
+            return String.format("%.3f K%s", value / 1000.0, unit);
         } else if (value < 1000000000) {
-            return String.format("%.1f M%s", value / 1000000.0, unit);
+            return String.format("%.3f M%s", value / 1000000.0, unit);
         } else {
-            return String.format("%.1f G%s", value / 1000000000.0, unit);
+            return String.format("%.3f G%s", value / 1000000000.0, unit);
         }
+    }
+
+    private UpfCounter sumUpfCounters(UpfCounter first, UpfCounter second) {
+        return UpfCounter.builder()
+                .setIngress(first.getIngressPkts() + second.getIngressPkts(),
+                            first.getIngressBytes() + second.getIngressBytes())
+                .setEgress(first.getEgressPkts() + second.getEgressPkts(),
+                           first.getEgressBytes() + second.getEgressBytes())
+                .withCellId(first.getCellId())
+                .build();
     }
 }

--- a/app/app/src/main/java/org/omecproject/up4/cli/FlowsStatsCommand.java
+++ b/app/app/src/main/java/org/omecproject/up4/cli/FlowsStatsCommand.java
@@ -1,6 +1,6 @@
 /*
  SPDX-License-Identifier: Apache-2.0
- SPDX-FileCopyrightText: 2022-present Open Networking Foundation <info@opennetworking.org>
+ SPDX-FileCopyrightText: 2022-present Intel Corporation
  */
 package org.omecproject.up4.cli;
 
@@ -41,7 +41,7 @@ public class FlowsStatsCommand extends AbstractShellCommand {
             valueToShowInHelp = "10.0.0.1")
     String ueSessionId = null;
 
-    @Option(name = "-c", aliases = "--continue",
+    @Option(name = "-w", aliases = "--watch",
             description = "Continue to print stats, until ctrl+c")
     boolean cont = false;
 

--- a/app/app/src/main/java/org/omecproject/up4/cli/FlowsStatsCommand.java
+++ b/app/app/src/main/java/org/omecproject/up4/cli/FlowsStatsCommand.java
@@ -31,7 +31,6 @@ public class FlowsStatsCommand extends AbstractShellCommand {
             required = false)
     int sleepTimeMs = DEFAULT_SLEEP_TIME;
 
-    // Add completer?
     @Argument(index = 1, name = "ue-session-id",
             description = "UE Session ID (IPv4 UE address)",
             required = false)

--- a/app/app/src/main/java/org/omecproject/up4/cli/FlowsStatsCommand.java
+++ b/app/app/src/main/java/org/omecproject/up4/cli/FlowsStatsCommand.java
@@ -31,7 +31,7 @@ public class FlowsStatsCommand extends AbstractShellCommand {
             valueToShowInHelp = "2")
     float sleepTimeS = DEFAULT_SLEEP_TIME;
 
-    @Option(name = "-s", aliases = "--session-id",
+    @Option(name = "-s", aliases = "--session",
             description = "UE Session ID (IPv4 UE address)",
             valueToShowInHelp = "10.0.0.1")
     String ueSessionId = null;

--- a/app/app/src/main/java/org/omecproject/up4/cli/FlowsStatsCommand.java
+++ b/app/app/src/main/java/org/omecproject/up4/cli/FlowsStatsCommand.java
@@ -1,0 +1,106 @@
+/*
+ SPDX-License-Identifier: Apache-2.0
+ SPDX-FileCopyrightText: 2022-present Intel Corporation
+ */
+package org.omecproject.up4.cli;
+
+import com.google.common.collect.Maps;
+import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+import org.omecproject.up4.impl.Up4AdminService;
+import org.onlab.packet.Ip4Address;
+import org.onosproject.cli.AbstractShellCommand;
+import org.onosproject.net.behaviour.upf.UpfCounter;
+
+import java.util.Map;
+
+/**
+ * UP4 UE flow stats.
+ */
+@Service
+@Command(scope = "up4", name = "flow-stats",
+        description = "Read all UE flows stats")
+public class FlowsStatsCommand extends AbstractShellCommand {
+
+    private static final String SEPARATOR = "-".repeat(40);
+    private static final int SLEEP_TIME_MS = 200;
+
+    @Override
+    protected void doExecute() throws Exception {
+        Up4AdminService adminService = get(Up4AdminService.class);
+
+        Map<Ip4Address, UpfCounter> beforeDownlink = Maps.newHashMap();
+        adminService.getDownlinkFlows().forEach(dlUpfFlow -> {
+            beforeDownlink.put(dlUpfFlow.getSession().ueAddress(), dlUpfFlow.getCounter());
+        });
+
+        Map<Ip4Address, UpfCounter> beforeUplink = Maps.newHashMap();
+        adminService.getUplinkFlows().forEach(ulUpfFlow -> {
+            beforeUplink.put(ulUpfFlow.getTermination().ueSessionId(), ulUpfFlow.getCounter());
+        });
+        Thread.sleep(SLEEP_TIME_MS);
+
+        Map<Ip4Address, UpfCounter> afterDownlink = Maps.newHashMap();
+        adminService.getDownlinkFlows().forEach(dlUpfFlow -> {
+            afterDownlink.put(dlUpfFlow.getSession().ueAddress(), dlUpfFlow.getCounter());
+        });
+
+        Map<Ip4Address, UpfCounter> afterUplink = Maps.newHashMap();
+        adminService.getUplinkFlows().forEach(ulUpfFlow -> {
+            afterUplink.put(ulUpfFlow.getTermination().ueSessionId(), ulUpfFlow.getCounter());
+        });
+
+        print(SEPARATOR);
+        if (!(beforeDownlink.keySet().equals(beforeUplink.keySet()) &&
+                beforeDownlink.keySet().equals(afterUplink) &&
+                beforeDownlink.keySet().equals(afterDownlink))) {
+            print("ERROR while reading stats!");
+            return;
+        }
+        for (Ip4Address ueSessionId : beforeDownlink.keySet()) {
+            if (!beforeUplink.containsKey(ueSessionId) || !afterDownlink.containsKey(ueSessionId) || !afterUplink.containsKey())
+            print("UE session: " + ueSessionId.toString());
+            UpfCounter bfUl = beforeUplink.get(ueSessionId);
+            UpfCounter bfDl = beforeDownlink.get(ueSessionId);
+            UpfCounter afUl = afterUplink.get(ueSessionId);
+            UpfCounter afDl = afterDownlink.get(ueSessionId);
+            long droppedPktsUl = (afUl.getIngressPkts() - afUl.getEgressPkts()) -
+                    (bfUl.getIngressPkts() - bfUl.getEgressPkts());
+            long droppedPktsDl = (afDl.getIngressPkts() - afDl.getEgressPkts()) -
+                    (bfDl.getIngressPkts() - bfDl.getEgressPkts());
+
+            long txPktsUl = (afUl.getEgressPkts() - bfUl.getEgressPkts()) / SLEEP_TIME_MS;
+            long txBytesUl = (afUl.getEgressBytes() - bfUl.getEgressBytes()) / SLEEP_TIME_MS;
+            long txPktsDl = (afDl.getEgressPkts() - bfDl.getEgressPkts()) / SLEEP_TIME_MS;
+            long txBytesDl = (afDl.getEgressBytes() - bfDl.getEgressBytes()) / SLEEP_TIME_MS;
+
+            long rxPktsUl = (afUl.getIngressPkts() - bfUl.getIngressPkts()) / SLEEP_TIME_MS;
+            long rxBytesUl = (afUl.getIngressBytes() - bfUl.getIngressBytes()) / SLEEP_TIME_MS;
+            long rxPktsDl = (afDl.getIngressPkts() - bfDl.getIngressPkts()) / SLEEP_TIME_MS;
+            long rxBytesDl = (afDl.getIngressBytes() - bfDl.getIngressBytes()) / SLEEP_TIME_MS;
+
+            print("UPLINK");
+            print("    RX:  %s  %s", toReadable(rxBytesUl, "Bps"), toReadable(rxPktsUl, "pkt/s"));
+            print("    TX:  %s  %s", toReadable(txBytesUl, "Bps"), toReadable(txPktsUl, "pkt/s"));
+            print("    DROPPED:  %d", droppedPktsDl);
+            print("DOWNLINK");
+            print("    RX:  %s  %s", toReadable(rxBytesDl, "Bps"), toReadable(rxPktsDl, "pkt/s"));
+            print("    TX:  %s  %s", toReadable(txBytesDl, "Bps"), toReadable(txPktsDl, "pkt/s"));
+            print("    DROPPED:  %d", droppedPktsUl);
+            print(SEPARATOR);
+        }
+
+    }
+
+    String toReadable(long value, String unit) {
+        if (value < 1000) {
+            return String.format("%.1f %s", (float) value, unit);
+        } else if (value < 1000000) {
+            return String.format("%.1f K%s", value / 1000.0, unit);
+        } else if (value < 1000000000) {
+            return String.format("%.1f M%s", value / 1000000.0, unit);
+        } else {
+            return String.format("%.1f G%s", value / 1000000000.0, unit);
+        }
+    }
+}

--- a/app/app/src/main/java/org/omecproject/up4/cli/FlowsStatsCommand.java
+++ b/app/app/src/main/java/org/omecproject/up4/cli/FlowsStatsCommand.java
@@ -58,38 +58,40 @@ public class FlowsStatsCommand extends AbstractShellCommand {
             return;
         }
         for (Ip4Address ueSessionId : beforeDownlink.keySet()) {
-            if (!beforeUplink.containsKey(ueSessionId) || !afterDownlink.containsKey(ueSessionId) || !afterUplink.containsKey())
-            print("UE session: " + ueSessionId.toString());
-            UpfCounter bfUl = beforeUplink.get(ueSessionId);
-            UpfCounter bfDl = beforeDownlink.get(ueSessionId);
-            UpfCounter afUl = afterUplink.get(ueSessionId);
-            UpfCounter afDl = afterDownlink.get(ueSessionId);
-            long droppedPktsUl = (afUl.getIngressPkts() - afUl.getEgressPkts()) -
-                    (bfUl.getIngressPkts() - bfUl.getEgressPkts());
-            long droppedPktsDl = (afDl.getIngressPkts() - afDl.getEgressPkts()) -
-                    (bfDl.getIngressPkts() - bfDl.getEgressPkts());
+            if (!beforeUplink.containsKey(ueSessionId) ||
+                    !afterDownlink.containsKey(ueSessionId) ||
+                    !afterUplink.containsKey(ueSessionId)) {
+                print("UE session: " + ueSessionId.toString());
+                UpfCounter bfUl = beforeUplink.get(ueSessionId);
+                UpfCounter bfDl = beforeDownlink.get(ueSessionId);
+                UpfCounter afUl = afterUplink.get(ueSessionId);
+                UpfCounter afDl = afterDownlink.get(ueSessionId);
+                long droppedPktsUl = (afUl.getIngressPkts() - afUl.getEgressPkts()) -
+                        (bfUl.getIngressPkts() - bfUl.getEgressPkts());
+                long droppedPktsDl = (afDl.getIngressPkts() - afDl.getEgressPkts()) -
+                        (bfDl.getIngressPkts() - bfDl.getEgressPkts());
 
-            long txPktsUl = (afUl.getEgressPkts() - bfUl.getEgressPkts()) / SLEEP_TIME_MS;
-            long txBytesUl = (afUl.getEgressBytes() - bfUl.getEgressBytes()) / SLEEP_TIME_MS;
-            long txPktsDl = (afDl.getEgressPkts() - bfDl.getEgressPkts()) / SLEEP_TIME_MS;
-            long txBytesDl = (afDl.getEgressBytes() - bfDl.getEgressBytes()) / SLEEP_TIME_MS;
+                long txPktsUl = (afUl.getEgressPkts() - bfUl.getEgressPkts()) / SLEEP_TIME_MS;
+                long txBytesUl = (afUl.getEgressBytes() - bfUl.getEgressBytes()) / SLEEP_TIME_MS;
+                long txPktsDl = (afDl.getEgressPkts() - bfDl.getEgressPkts()) / SLEEP_TIME_MS;
+                long txBytesDl = (afDl.getEgressBytes() - bfDl.getEgressBytes()) / SLEEP_TIME_MS;
 
-            long rxPktsUl = (afUl.getIngressPkts() - bfUl.getIngressPkts()) / SLEEP_TIME_MS;
-            long rxBytesUl = (afUl.getIngressBytes() - bfUl.getIngressBytes()) / SLEEP_TIME_MS;
-            long rxPktsDl = (afDl.getIngressPkts() - bfDl.getIngressPkts()) / SLEEP_TIME_MS;
-            long rxBytesDl = (afDl.getIngressBytes() - bfDl.getIngressBytes()) / SLEEP_TIME_MS;
+                long rxPktsUl = (afUl.getIngressPkts() - bfUl.getIngressPkts()) / SLEEP_TIME_MS;
+                long rxBytesUl = (afUl.getIngressBytes() - bfUl.getIngressBytes()) / SLEEP_TIME_MS;
+                long rxPktsDl = (afDl.getIngressPkts() - bfDl.getIngressPkts()) / SLEEP_TIME_MS;
+                long rxBytesDl = (afDl.getIngressBytes() - bfDl.getIngressBytes()) / SLEEP_TIME_MS;
 
-            print("UPLINK");
-            print("    RX:  %s  %s", toReadable(rxBytesUl, "Bps"), toReadable(rxPktsUl, "pkt/s"));
-            print("    TX:  %s  %s", toReadable(txBytesUl, "Bps"), toReadable(txPktsUl, "pkt/s"));
-            print("    DROPPED:  %d", droppedPktsDl);
-            print("DOWNLINK");
-            print("    RX:  %s  %s", toReadable(rxBytesDl, "Bps"), toReadable(rxPktsDl, "pkt/s"));
-            print("    TX:  %s  %s", toReadable(txBytesDl, "Bps"), toReadable(txPktsDl, "pkt/s"));
-            print("    DROPPED:  %d", droppedPktsUl);
-            print(SEPARATOR);
+                print("UPLINK");
+                print("    RX:  %s  %s", toReadable(rxBytesUl, "Bps"), toReadable(rxPktsUl, "pkt/s"));
+                print("    TX:  %s  %s", toReadable(txBytesUl, "Bps"), toReadable(txPktsUl, "pkt/s"));
+                print("    DROPPED:  %d", droppedPktsDl);
+                print("DOWNLINK");
+                print("    RX:  %s  %s", toReadable(rxBytesDl, "Bps"), toReadable(rxPktsDl, "pkt/s"));
+                print("    TX:  %s  %s", toReadable(txBytesDl, "Bps"), toReadable(txPktsDl, "pkt/s"));
+                print("    DROPPED:  %d", droppedPktsUl);
+                print(SEPARATOR);
+            }
         }
-
     }
 
     String toReadable(long value, String unit) {

--- a/app/app/src/main/java/org/omecproject/up4/cli/FlowsStatsCommand.java
+++ b/app/app/src/main/java/org/omecproject/up4/cli/FlowsStatsCommand.java
@@ -5,8 +5,8 @@
 package org.omecproject.up4.cli;
 
 import com.google.common.collect.Maps;
-import org.apache.karaf.shell.api.action.Argument;
 import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.Option;
 import org.apache.karaf.shell.api.action.lifecycle.Service;
 import org.omecproject.up4.impl.Up4AdminService;
 import org.onlab.packet.Ip4Address;
@@ -16,131 +16,191 @@ import org.onosproject.net.behaviour.upf.UpfCounter;
 import java.util.Map;
 
 /**
- * UP4 UE flow stats.
+ * UP4 UE traffic statistics.
  */
 @Service
-@Command(scope = "up4", name = "flow-stats",
+@Command(scope = "up4", name = "upf-stats",
         description = "Read all UE flows stats")
 public class FlowsStatsCommand extends AbstractShellCommand {
 
     private static final String SEPARATOR = "-".repeat(40);
-    private static final int DEFAULT_SLEEP_TIME = 2000; // 2 seconds
+    private static final float DEFAULT_SLEEP_TIME = 2; // 2 seconds
 
-    @Argument(index = 0, name = "sleep-time",
-            description = "Time between counter reads",
-            required = false)
-    int sleepTimeMs = DEFAULT_SLEEP_TIME;
+    @Option(name = "-t", aliases = "--time",
+            description = "Time between counter reads (seconds)",
+            valueToShowInHelp = "2")
+    float sleepTimeS = DEFAULT_SLEEP_TIME;
 
-    @Argument(index = 1, name = "ue-session-id",
+    @Option(name = "-s", aliases = "--session-id",
             description = "UE Session ID (IPv4 UE address)",
-            required = false)
+            valueToShowInHelp = "10.0.0.1")
     String ueSessionId = null;
+
+    @Option(name = "-c", aliases = "--continue",
+            description = "Continue to print stats, until ctrl+c")
+    boolean cont = false;
+
+    @Option(name = "-d", aliases = "--debug",
+            description = "Print debug stats")
+    boolean debug = false;
 
     @Override
     protected void doExecute() throws Exception {
         Up4AdminService adminService = get(Up4AdminService.class);
         Ip4Address ueAddr = ueSessionId != null ? Ip4Address.valueOf(ueSessionId) : null;
+        do {
+            Map<Ip4Address, UpfCounter> beforeDownlink = Maps.newHashMap();
+            adminService.getDownlinkFlows().stream()
+                    .filter(upfFlow -> ueAddr == null || ueAddr.equals(upfFlow.getTermination().ueSessionId()))
+                    .forEach(
+                            dlUpfFlow -> beforeDownlink.compute(
+                                    dlUpfFlow.getTermination().ueSessionId(),
+                                    (key, value) -> (value == null) ?
+                                            dlUpfFlow.getCounter() :
+                                            sumUpfCounters(value, dlUpfFlow.getCounter())
+                            )
+                    );
+            Map<Ip4Address, UpfCounter> beforeUplink = Maps.newHashMap();
+            adminService.getUplinkFlows().stream()
+                    .filter(upfFlow -> ueAddr == null || ueAddr.equals(upfFlow.getTermination().ueSessionId()))
+                    .forEach(
+                            ulUpfFlow -> beforeUplink.compute(
+                                    ulUpfFlow.getTermination().ueSessionId(),
+                                    (key, value) -> (value == null) ?
+                                            ulUpfFlow.getCounter() :
+                                            sumUpfCounters(value, ulUpfFlow.getCounter())
+                            )
+                    );
 
-        Map<Ip4Address, UpfCounter> beforeDownlink = Maps.newHashMap();
-        adminService.getDownlinkFlows().stream()
-                .filter(upfFlow -> ueAddr == null || ueAddr.equals(upfFlow.getTermination().ueSessionId()))
-                .forEach(
-                        dlUpfFlow -> beforeDownlink.compute(
-                                dlUpfFlow.getTermination().ueSessionId(),
-                                (key, value) -> (value == null) ?
-                                        dlUpfFlow.getCounter() :
-                                        sumUpfCounters(value, dlUpfFlow.getCounter())
-                        )
-                );
-
-        Map<Ip4Address, UpfCounter> beforeUplink = Maps.newHashMap();
-        adminService.getUplinkFlows().stream()
-                .filter(upfFlow -> ueAddr == null || ueAddr.equals(upfFlow.getTermination().ueSessionId()))
-                .forEach(
-                        ulUpfFlow -> beforeUplink.compute(
-                                ulUpfFlow.getTermination().ueSessionId(),
-                                (key, value) -> (value == null) ?
-                                        ulUpfFlow.getCounter() :
-                                        sumUpfCounters(value, ulUpfFlow.getCounter())
-                        )
-                );
-
-        if (beforeDownlink.isEmpty() || beforeUplink.isEmpty()) {
-            print("No UE Sessions");
-            return;
-        }
-        Thread.sleep(sleepTimeMs);
-
-        Map<Ip4Address, UpfCounter> afterDownlink = Maps.newHashMap();
-        adminService.getDownlinkFlows().stream()
-                .filter(upfFlow -> ueAddr == null || ueAddr.equals(upfFlow.getTermination().ueSessionId()))
-                .forEach(
-                        dlUpfFlow -> afterDownlink.compute(
-                                dlUpfFlow.getTermination().ueSessionId(),
-                                (key, value) -> (value == null) ?
-                                        dlUpfFlow.getCounter() :
-                                        sumUpfCounters(value, dlUpfFlow.getCounter())
-                        )
-                );
-
-        Map<Ip4Address, UpfCounter> afterUplink = Maps.newHashMap();
-        adminService.getUplinkFlows().stream()
-                .filter(upfFlow -> ueAddr == null || ueAddr.equals(upfFlow.getTermination().ueSessionId()))
-                .forEach(
-                        ulUpfFlow -> afterUplink.compute(
-                                ulUpfFlow.getTermination().ueSessionId(),
-                                (key, value) -> (value == null) ?
-                                        ulUpfFlow.getCounter() :
-                                        sumUpfCounters(value, ulUpfFlow.getCounter())
-                        )
-                );
-
-        if (!(beforeDownlink.keySet().containsAll(beforeUplink.keySet()) &&
-                beforeDownlink.keySet().equals(afterUplink.keySet()) &&
-                beforeDownlink.keySet().equals(afterDownlink.keySet()))) {
-            print("Error while reading stats!");
-            return;
-        }
-
-        print(SEPARATOR);
-        for (Ip4Address ueSessionId : beforeDownlink.keySet()) {
-            if (ueAddr == null || ueAddr.equals(ueSessionId)) {
-                print("UE session: " + ueSessionId.toString());
-                UpfCounter bfUl = beforeUplink.get(ueSessionId);
-                UpfCounter bfDl = beforeDownlink.get(ueSessionId);
-                UpfCounter afUl = afterUplink.get(ueSessionId);
-                UpfCounter afDl = afterDownlink.get(ueSessionId);
-                long droppedPktsUl = (afUl.getIngressPkts() - afUl.getEgressPkts()) -
-                        (bfUl.getIngressPkts() - bfUl.getEgressPkts());
-                long droppedPktsDl = (afDl.getIngressPkts() - afDl.getEgressPkts()) -
-                        (bfDl.getIngressPkts() - bfDl.getEgressPkts());
-
-                double txPktsUl = (afUl.getEgressPkts() - bfUl.getEgressPkts()) / (sleepTimeMs / 1000.0);
-                double txBytesUl = ((afUl.getEgressBytes() - bfUl.getEgressBytes()) * 8) / (sleepTimeMs / 1000.0);
-                double txPktsDl = (afDl.getEgressPkts() - bfDl.getEgressPkts()) / (sleepTimeMs / 1000.0);
-                double txBytesDl = ((afDl.getEgressBytes() - bfDl.getEgressBytes()) * 8) / (sleepTimeMs / 1000.0);
-
-                double rxPktsUl = (afUl.getIngressPkts() - bfUl.getIngressPkts()) / (sleepTimeMs / 1000.0);
-                double rxPktsDl = (afDl.getIngressPkts() - bfDl.getIngressPkts()) / (sleepTimeMs / 1000.0);
-
-                print("Uplink");
-                print("  tput: %s / %s (%.1f%% dropped)",
-                      toReadable(txBytesUl, "bps"),
-                      toReadable(txPktsUl, "pps"),
-                      rxPktsUl == 0 ? 0.0 : (droppedPktsUl / rxPktsUl) * 100.0);
-                print("Downlink");
-                print("  tput: %s / %s (%.1f%% dropped)",
-                      toReadable(txBytesDl, "bps"),
-                      toReadable(txPktsDl, "pps"),
-                      rxPktsDl == 0 ? 0.0 : (droppedPktsDl / rxPktsDl) * 100.0);
-                print(SEPARATOR);
+            if (beforeDownlink.isEmpty() || beforeUplink.isEmpty()) {
+                print("No UE Sessions\n");
+                if (cont) {
+                    Thread.sleep((int) (sleepTimeS * 1000));
+                }
+                continue;
             }
-        }
+
+            Thread.sleep((int) (sleepTimeS * 1000));
+
+            Map<Ip4Address, UpfCounter> afterDownlink = Maps.newHashMap();
+            adminService.getDownlinkFlows().stream()
+                    .filter(upfFlow -> ueAddr == null || ueAddr.equals(upfFlow.getTermination().ueSessionId()))
+                    .forEach(
+                            dlUpfFlow -> afterDownlink.compute(
+                                    dlUpfFlow.getTermination().ueSessionId(),
+                                    (key, value) -> (value == null) ?
+                                            dlUpfFlow.getCounter() :
+                                            sumUpfCounters(value, dlUpfFlow.getCounter())
+                            )
+                    );
+            Map<Ip4Address, UpfCounter> afterUplink = Maps.newHashMap();
+            adminService.getUplinkFlows().stream()
+                    .filter(upfFlow -> ueAddr == null || ueAddr.equals(upfFlow.getTermination().ueSessionId()))
+                    .forEach(
+                            ulUpfFlow -> afterUplink.compute(
+                                    ulUpfFlow.getTermination().ueSessionId(),
+                                    (key, value) -> (value == null) ?
+                                            ulUpfFlow.getCounter() :
+                                            sumUpfCounters(value, ulUpfFlow.getCounter())
+                            )
+                    );
+
+            if (!(beforeDownlink.keySet().containsAll(beforeUplink.keySet()) &&
+                    beforeDownlink.keySet().equals(afterUplink.keySet()) &&
+                    beforeDownlink.keySet().equals(afterDownlink.keySet()))) {
+                print("Error while reading stats!\n");
+                continue;
+            }
+
+            print(SEPARATOR);
+            for (Ip4Address ueSessionId : beforeDownlink.keySet()) {
+                if (ueAddr == null || ueAddr.equals(ueSessionId)) {
+                    print("Session: " + ueSessionId.toString());
+                    UpfCounter bfUl = beforeUplink.get(ueSessionId);
+                    UpfCounter bfDl = beforeDownlink.get(ueSessionId);
+                    UpfCounter afUl = afterUplink.get(ueSessionId);
+                    UpfCounter afDl = afterDownlink.get(ueSessionId);
+
+                    long rxPktsUl = afUl.getIngressPkts() - bfUl.getIngressPkts();
+                    long rxPktsDl = afDl.getIngressPkts() - bfDl.getIngressPkts();
+                    long txPktsUl = afUl.getEgressPkts() - bfUl.getEgressPkts();
+                    long txPktsDl = afDl.getEgressPkts() - bfDl.getEgressPkts();
+
+                    long rxBitsUl = (afUl.getIngressBytes() - bfUl.getIngressBytes()) * 8;
+                    long rxBitsDl = (afDl.getIngressBytes() - bfDl.getIngressBytes()) * 8;
+                    long txBitsUl = (afUl.getEgressBytes() - bfUl.getEgressBytes()) * 8;
+                    long txBitsDl = (afDl.getEgressBytes() - bfDl.getEgressBytes()) * 8;
+
+                    long droppedPktsUl = (afUl.getIngressPkts() - afUl.getEgressPkts()) -
+                            (bfUl.getIngressPkts() - bfUl.getEgressPkts());
+                    long droppedPktsDl = (afDl.getIngressPkts() - afDl.getEgressPkts()) -
+                            (bfDl.getIngressPkts() - bfDl.getEgressPkts());
+                    long droppedBitsUl = ((afUl.getIngressPkts() - afUl.getEgressPkts()) -
+                            (bfUl.getIngressPkts() - bfUl.getEgressPkts())) * 8;
+                    long droppedBitsDl = ((afDl.getIngressBytes() - afDl.getEgressBytes()) -
+                            (bfDl.getIngressBytes() - bfDl.getEgressBytes())) * 8;
+
+                    print("  Uplink: %s / %s (%.2f%% dropped)",
+                          toReadable((double) txBitsUl / sleepTimeS, "bps"),
+                          toReadable((double) txPktsUl / sleepTimeS, "pps"),
+                          rxPktsUl == 0 ? 0.0 : ((double) droppedPktsUl / (double) rxPktsUl) * 100.0);
+                    if (droppedPktsUl > rxPktsUl) {
+                        print("    More dropped packets than received! (%d > %d)", droppedPktsUl, rxPktsUl);
+                    }
+                    if (debug) {
+                        print("    RX: %s / %s",
+                              toReadable(rxPktsUl, "pkts"),
+                              toReadable(rxBitsUl, "bit"));
+                        print("    TX: %s / %s",
+                              toReadable(txPktsUl, "pkts"),
+                              toReadable(txBitsUl, "bit"));
+                        print("    Dropped: %s / %s",
+                              toReadable(droppedPktsUl, "pkts"),
+                              toReadable(droppedBitsUl, "bit"));
+                    }
+
+                    print("  Downlink: %s / %s (%.2f%% dropped)",
+                          toReadable((double) txBitsDl / sleepTimeS, "bps"),
+                          toReadable((double) txPktsDl / sleepTimeS, "pps"),
+                          rxPktsDl == 0 ? 0.0 : ((double) droppedPktsDl / (double) rxPktsDl) * 100.0);
+                    if (droppedPktsDl > rxPktsDl) {
+                        print("    More dropped packets than received! (%d > %d)", droppedPktsDl, rxPktsDl);
+                    }
+                    if (debug) {
+                        print("    RX: %s / %s",
+                              toReadable(rxPktsDl, "pkts"),
+                              toReadable(rxBitsDl, "bit"));
+                        print("    TX: %s / %s",
+                              toReadable(txPktsDl, "pkts"),
+                              toReadable(txBitsDl, "bit"));
+                        print("    Dropped: %s / %s",
+                              toReadable(droppedPktsDl, "pkts"),
+                              toReadable(droppedBitsDl, "bit"));
+                    }
+                    print(SEPARATOR);
+                }
+            }
+            if (cont) {
+                print("");
+            }
+        } while (cont);
     }
 
     private String toReadable(double value, String unit) {
         if (value < 1000) {
             return String.format("%.3f %s", value, unit);
+        } else if (value < 1000000) {
+            return String.format("%.3f K%s", value / 1000.0, unit);
+        } else if (value < 1000000000) {
+            return String.format("%.3f M%s", value / 1000000.0, unit);
+        } else {
+            return String.format("%.3f G%s", value / 1000000000.0, unit);
+        }
+    }
+
+    private String toReadable(long value, String unit) {
+        if (value < 1000) {
+            return String.format("%d %s", value, unit);
         } else if (value < 1000000) {
             return String.format("%.3f K%s", value / 1000.0, unit);
         } else if (value < 1000000000) {


### PR DESCRIPTION
Output example:
```
----------------------------------------
Session: 17.0.0.1
  Uplink: 0.000 bps / 0.000 pps (0.00% dropped)
  Downlink: 1.058 Mbps / 87.500 pps (51.52% dropped)
----------------------------------------
```

Output example in debug mode:
``` 
dmoro@root > upf-stats -d
----------------------------------------
Session: 17.0.0.1
  Uplink: 0.000 bps / 0.000 pps (0.00% dropped)
    RX: 0 pkts / 0 bit
    TX: 0 pkts / 0 bit
    Dropped: 0 pkts / 0 bit
  Downlink: 1.064 Mbps / 88.000 pps (51.78% dropped)
    RX: 365 pkts / 4.415 Mbit
    TX: 176 pkts / 2.129 Mbit
    Dropped: 189 pkts / 2.286 Mbit
----------------------------------------
```

`-w` option will continue showing stats every 2 seconds (time interval can be changed with `-t [seconds]` option).