### PR TITLE
Use custom token for opening PR from GHA

### DIFF
--- a/.github/workflows/changeStableEnv.yml
+++ b/.github/workflows/changeStableEnv.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        token: ${{ secrets.ONF_BOT_GH_TOKEN }}
     - name: Read sdfabric ONOS image from stable env
       run: echo ONOS_IMAGE=$(cat .env.stable | grep "ONOS_IMAGE="| sed "s/ONOS_IMAGE=//") >> $GITHUB_ENV
     - name: Pull latest sdfabric ONOS image
@@ -38,6 +40,7 @@ jobs:
       if: ${{ env.ONOS_IMAGE }} == 'sdfabric-onos-local:master'
       uses: peter-evans/create-pull-request@v3
       with:
+        token: ${{ secrets.ONF_BOT_GH_TOKEN }}
         commit-message: Update stable env to latest sdfabric-onos image
         title: Update stable env to latest sdfabric-onos image
         # Always push on the same branch, commit will appear on the same PR if it's still open.

--- a/.github/workflows/prettify.yml
+++ b/.github/workflows/prettify.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.ONF_BOT_GH_TOKEN }}
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
@@ -23,6 +25,7 @@ jobs:
       uses: peter-evans/create-pull-request@v3
       with:
         commit-message: Auto-prettify ${{ github.sha }}
+        token: ${{ secrets.ONF_BOT_GH_TOKEN }}
         title: Auto-prettify 💅
         labels: prettybot
         branch: prettybot


### PR DESCRIPTION
To trigger CI (especially GHA) on PR opened by bots, we need to use a different GitHub Token, instead of that associated to the GitHub Actions bot. See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow