### PR TITLE
Add logging to show counter writing

### DIFF
--- a/.env.stable
+++ b/.env.stable
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-master-latest-ceb1eca
+
 PFCP_AGENT_IMAGE=omecproject/upf-epc-pfcpiface:master-latest-ceb1eca
 ONOS_IMAGE=opennetworking/sdfabric-onos@sha256:071a3eb2c8acdf719a97c6a17f77ee45304288560c2d663fe447dc9542ba6005
 PFCPSIM_IMAGE=opennetworking/pfcpsim:64474e9

--- a/.env.stable
+++ b/.env.stable
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-
-PFCP_AGENT_IMAGE=ghcr.io/omec-project/upf-epc/upf-epc-pfcpiface:pr-607
+master-latest-ceb1eca
+PFCP_AGENT_IMAGE=omecproject/upf-epc-pfcpiface:master-latest-ceb1eca
 ONOS_IMAGE=opennetworking/sdfabric-onos@sha256:071a3eb2c8acdf719a97c6a17f77ee45304288560c2d663fe447dc9542ba6005
 PFCPSIM_IMAGE=opennetworking/pfcpsim:64474e9
 ATOMIX_IMAGE=atomix/atomix:3.1.12

--- a/.env.stable
+++ b/.env.stable
@@ -3,7 +3,7 @@
 #
 
 
-PFCP_AGENT_IMAGE=omecproject/upf-epc-pfcpiface:master-2f04e3a
+PFCP_AGENT_IMAGE=ghcr.io/omec-project/upf-epc/upf-epc-pfcpiface:pr-607
 ONOS_IMAGE=opennetworking/sdfabric-onos@sha256:071a3eb2c8acdf719a97c6a17f77ee45304288560c2d663fe447dc9542ba6005
 PFCPSIM_IMAGE=opennetworking/pfcpsim:64474e9
 ATOMIX_IMAGE=atomix/atomix:3.1.12

--- a/app/app/src/main/java/org/omecproject/up4/impl/Up4NorthComponent.java
+++ b/app/app/src/main/java/org/omecproject/up4/impl/Up4NorthComponent.java
@@ -774,6 +774,7 @@ public class Up4NorthComponent {
                 switch (requestEntity.getEntityCase()) {
                     case COUNTER_ENTRY:
                         // TODO: support counter cell writes, including wildcard writes
+                        log.info("Got counter write request, silently ignoring it: {}", requestEntity);
                         break;
                     case METER_ENTRY:
                         PiEntity piMeterEntity;

--- a/scenarios/config/pfcp-agent/config.json
+++ b/scenarios/config/pfcp-agent/config.json
@@ -9,7 +9,6 @@
     "p4rtc_port": "51001",
     "access_ip": "140.0.0.1/32",
     "slice_id": 15,
-    "default_tc": 3,
-    "clear_state_on_restart": true
+    "default_tc": 3
   }
 }

--- a/scenarios/config/pfcp-agent/config.json
+++ b/scenarios/config/pfcp-agent/config.json
@@ -9,6 +9,7 @@
     "p4rtc_port": "51001",
     "access_ip": "140.0.0.1/32",
     "slice_id": 15,
-    "default_tc": 3
+    "default_tc": 3,
+    "clear_state_on_restart": true
   }
 }


### PR DESCRIPTION
We still don't support counter writing, but PFCP-agent will start issuing counter write.
For debugging, we logs those write request, without doing any action on the data plane, while replying positively to pfcp-agent.